### PR TITLE
FIX: Ensure deferred CMS panels are locale-specific (fixes #94)

### DIFF
--- a/javascript/fluent.js
+++ b/javascript/fluent.js
@@ -1,20 +1,36 @@
-
-		
-				
 (function($) {
-	
 	/**
 	 * File: fluent.js
 	 * 
 	 * Injects locale navigation menu into the website
 	 */
 	$.entwine('ss', function($) {
+		/**
+		 * Determine the url to navigate to given the specified locale
+		 */
+		var urlForLocale = function(url, locale) {
+			// Get new locale code
+			param = {}
+			param[fluentParam] = locale;
+
+			// Check existing url
+			search = new RegExp('\\b'+fluentParam+'=[^&#]*');
+			if(url.match(search)) {
+				// Replace locale code
+				url = url.replace(search, $.param(param));
+			} else {
+				// Add locale code
+				url = $.path.addSearchParams(url, param);
+			}
+
+			// Remove hash. See https://github.com/tractorcow/silverstripe-fluent/issues/90
+			return url.split('#')[0];
+		};
 
 		/**
 		 * Activation for cms menu
 		 */
 		$('.cms > .cms-container > .cms-menu > .cms-panel-content.center').entwine({
-			
 			/**
 			 * Generate the locale selector when activated
 			 */
@@ -27,7 +43,7 @@
 						<a class='cms-fluent-selector-flydown' type='button' title='"+fluentButtonTitle+"'><span class='icon icon-fluent-select'>"+fluentButtonTitle+"</span></a>\
 						<ul class='cms-fluent-selector-locales'></ul>\
 					</div>");
-				
+
 				// Create options
 				$.each(fluentLocales, function(locale, name){
 					var item = $("<li><a></a></li>");
@@ -36,14 +52,14 @@
 						.attr('data-locale', locale);
 					$(".cms-fluent-selector-locales", selector).append(item);
 				});
-				
+
 				// Display selected locale
 				$(".text", selector).text(fluentLocales[fluentLocale]);
-				
+
 				this.prepend(selector);
 			}
 		});
-				
+
 		/**
 		 * Selector container
 		 */
@@ -55,52 +71,42 @@
 				this.toggleClass('active');
 			}
 		});
-		
+
 		/**
 		 * Locale links
 		 */
 		$(".cms-fluent-selector .cms-fluent-selector-locales a").entwine({
-			/**
-			 * Determine the url to navigate to given the specified locale
-			 */
-			urlForLocale: function(locale) {
-				
-				// Get new locale code
-				param = {}
-				param[fluentParam] = locale;
-
-				// Check existing url
-				search = new RegExp('\\b'+fluentParam+'=[^&#]*');
-				url = document.location.href;
-				if(url.match(search)) {
-					// Replace locale code
-					url = url.replace(search, $.param(param));
-				} else {
-					// Add locale code
-					url = $.path.addSearchParams(url, param);
-				}
-				
-				// Remove hash. See https://github.com/tractorcow/silverstripe-fluent/issues/90
-				return url.split('#')[0];
-			},
 			/**
 			 * Takes the user to the selected locale
 			 */
 			onclick: function(event) {
 				event.preventDefault();
 				locale = this.attr('data-locale');
-				url = this.urlForLocale(locale);
-				
+				url = urlForLocale(document.location.href, locale);
+
 				// Load panel
 				$('.cms-container').loadPanel(url);
-				
+
 				// Update selector
 				$(".cms-fluent-selector")
 					.removeClass("active")
 					.find(".text")
 						.text(fluentLocales[locale]);
-				
+
 				return false;
+			}
+		});
+
+		$('.cms-panel-deferred').entwine({
+			/**
+			 * Ensure that any deferred panel URLs include the locale parameter in their URL
+			 */
+			onadd: function() {
+				var url = this.attr('data-url'),
+					newUrl = urlForLocale(url, $.cookie('FluentLocale_CMS'));
+
+				this.attr('data-url', newUrl);
+				this._super();
 			}
 		});
 	});


### PR DESCRIPTION
- Moved `urlForLocale` so it’s not bound to a selector, changed it to accept a URL as an argument rather than assume `document.location.href` is the URL in question;
- Updated `$(".cms-fluent-selector .cms-fluent-selector-locales a").onclick()` to reflect new `urlForLocale` logic;
- Added `$('.cms-panel-deferred').onadd()` to add the fluent locale parameter to the deferred URL

I initially tried just disabling the deferred panels from ever being cached, but I think this is a better approach as it keeps that caching in-place. It’s not specific to the CMS tree view (#94 is the issue I’m trying to fix), but I don’t think that matters.