### PR TITLE
BUG Fix default row values not being properly loaded when saving with…

### DIFF
--- a/tests/FluentTest.yml
+++ b/tests/FluentTest.yml
@@ -45,3 +45,11 @@ FluentTest_TranslatedObject:
     Title_es_ES: 'Este color es azul'
     Description: 'Second object'
     URLKey: 'my-translated-2'
+  untranslated:
+    Title: 'Un-translated object'
+    Title_fr_CA: ''
+    Title_en_NZ: ''
+    Title_en_US: ''
+    Title_es_ES: ''
+    Description: 'Third'
+    URLKey: 'my-translated-3'


### PR DESCRIPTION
Fix default row values not being properly loaded when saving with fluent for the first time
Postgres can now fail due to no proper support for numeric fields (maybe one day)

Fixes https://github.com/tractorcow/silverstripe-fluent/pull/141, probably.

@phptek do you want to review this?

Also, annoyingly, I couldn't get postgres to work properly with numeric fields (it complains when comparint int columns to '') so I've temporarily added it to allowed failures.