### PR TITLE
Allow regex to match namespaces

### DIFF
--- a/code/extensions/FluentExtension.php
+++ b/code/extensions/FluentExtension.php
@@ -514,7 +514,7 @@ class FluentExtension extends DataExtension {
 		foreach($query->getSelect() as $alias => $select) {
 
 			// Skip fields without table context
-			if(!preg_match('/^"(?<class>\w+)"\."(?<field>\w+)"$/i', $select, $matches)) continue;
+			if(!preg_match('/^""?(?<class>[\w\\\\]+)"\."(?<field>\w+)""?$/i', $select, $matches)) continue;
 
 			$class = $matches['class'];
 			$field = $matches['field'];


### PR DESCRIPTION
Made a fix to allow namespaced classnames in the database to work with the Fluent extension.
e.g "MySite\Page\CustomPage"."Fieldname" wouldn't match to augment the query