### PR TITLE
BUG Ensure that new pages are overwritten on first save, even if saved in non-default locale

### DIFF
--- a/code/extensions/FluentExtension.php
+++ b/code/extensions/FluentExtension.php
@@ -124,6 +124,30 @@ class FluentExtension extends DataExtension
     }
 
     /**
+     * Copies current value of this record to the values in the given locale.
+     *
+     * Useful when writing a record to multiple locales in a single write.
+     *
+     * Note: Won't have any effect when writing to the current locale, since that
+     * locale will be written to anyway.
+     *
+     * @param string $locale
+     */
+    public function copyFieldsToLocale($locale) {
+        // Iterate over all localised fields in all tables
+        $includedTables = $this->getTranslatedTables();
+        foreach ($includedTables as $class => $fields) {
+            foreach ($fields as $field) {
+                // Copy to this locale
+                // (Title => Title_fr_FR)
+                $value = $this->owner->getField($field);
+                $updateField = Fluent::db_field_for_locale($field, $locale);
+                $this->owner->setField($updateField, $value);
+            }
+        }
+    }
+
+    /**
      * Splits a spec string safely, considering quoted columns, whitespace,
      * and cleaning brackets
      *

--- a/code/extensions/FluentSiteTree.php
+++ b/code/extensions/FluentSiteTree.php
@@ -6,9 +6,11 @@
  * @see SiteTree
  * @package fluent
  * @author Damian Mooyman <damian.mooyman@gmail.com>
+ * @property SiteTree $owner
  */
 class FluentSiteTree extends FluentExtension
 {
+
     public function MetaTags(&$tags)
     {
         $tags .= $this->owner->renderWith('FluentSiteTree_MetaTags');
@@ -18,6 +20,16 @@ class FluentSiteTree extends FluentExtension
     {
         // Fix issue with MenuTitle not containing the correct translated value
         $this->owner->setField('MenuTitle', $this->owner->MenuTitle);
+
+        // If default locale isn't translated (Title is "new page") then copy all fields over from
+        // current locale to default locale.
+        if(Fluent::current_locale() !== Fluent::default_locale()) {
+            $defaultLocaleTitle = Fluent::db_field_for_locale('Title', Fluent::default_locale());
+            if(stripos($this->owner->getField($defaultLocaleTitle), 'new') === 0) {
+                // Overwrite locale copy from this locale to default
+                $this->copyFieldsToLocale(Fluent::default_locale());
+            }
+        }
 
         parent::onBeforeWrite();
     }


### PR DESCRIPTION
Fixes #214

Just in case @phptek thinks I've stopped maintaining this module. :)