### PR TITLE
FIX: $manipulation updated for empty fields

### DIFF
--- a/code/extensions/FluentExtension.php
+++ b/code/extensions/FluentExtension.php
@@ -665,7 +665,7 @@ class FluentExtension extends DataExtension
             foreach ($includedTables[$class] as $field) {
 
                 // Skip translated field if not updated in this request
-                if (!isset($updates['fields'][$field])) {
+                if (!array_key_exists($field, $updates['fields'])) {
                     continue;
                 }
 


### PR DESCRIPTION
Fixed an issue where deleting all text in a translated field and saving the object did not update the locale field in the DB. Fixes #204 