### PR TITLE
Add default fallback to current locale to canViewInLocale

### DIFF
--- a/code/extensions/FluentFilteredExtension.php
+++ b/code/extensions/FluentFilteredExtension.php
@@ -48,13 +48,16 @@ class FluentFilteredExtension extends DataExtension
     }
 
     /**
-     * Determine if this object is visible (or excluded) in the specified locale
+     * Determine if this object is visible (or excluded) in the specified (or current) locale
      *
-     * @param string $locale Locale to check against
-     * @return boolean True if the object is visible in the specified locale
+     * @param  string|null $locale Locale to check against. If null, will use the current locale.
+     * @return boolean             True if the object is visible in the specified locale
      */
-    public function canViewInLocale($locale)
+    public function canViewInLocale($locale = null)
     {
+        if (is_null($locale)) {
+            $locale = Fluent::current_locale();
+        }
         $field = Fluent::db_field_for_locale("LocaleFilter", $locale);
         return $this->owner->$field;
     }


### PR DESCRIPTION
Hey Damian,

This is just optional - thought it might make it easier in situations where you might only need to check if an object is visible in the current locale, e.g.:

```php
foreach ($relations as $object) {
    if (!$object->hasExtension('FluentFilteredExtension') || $object->canViewInLocale()) {
        // use it
    }
}
```

As opposed to `$object->canViewInLocale(Fluent::current_locale())`