### PR TITLE
Add visual UI indicator for whether you are editing in the default locale or not

### DIFF
--- a/code/extensions/FluentExtension.php
+++ b/code/extensions/FluentExtension.php
@@ -553,9 +553,9 @@ class FluentExtension extends DataExtension
     protected function localiseSelect($class, $select, $fallback)
     {
         return "CASE COALESCE(CAST(\"{$class}\".\"{$select}\" AS CHAR), '')
-				WHEN '' THEN \"{$class}\".\"{$fallback}\"
-				WHEN '0' THEN \"{$class}\".\"{$fallback}\"
-				ELSE \"{$class}\".\"{$select}\" END";
+                WHEN '' THEN \"{$class}\".\"{$fallback}\"
+                WHEN '0' THEN \"{$class}\".\"{$fallback}\"
+                ELSE \"{$class}\".\"{$select}\" END";
     }
 
     public function augmentSQL(SQLQuery &$query, DataQuery &$dataQuery = null)
@@ -813,6 +813,36 @@ class FluentExtension extends DataExtension
                 }
             }
         }
+
+        $this->addLocaleIndicatorMessage($fields);
+    }
+
+    /**
+     * Adds a UI message to indicate whether you're editing in the default locale or not
+     *
+     * @param  FieldList $fields
+     * @return self
+     */
+    protected function addLocaleIndicatorMessage(FieldList $fields)
+    {
+        $localeNames     = Fluent::locale_names();
+        $isDefaultLocale = (Fluent::default_locale() === Fluent::current_locale());
+        $messageClass    = ($isDefaultLocale) ? 'good' : 'notice';
+        $message         = ($isDefaultLocale)
+            ? _t('Fluent.DefaultLocale', 'This is the default locale')
+            : _t('Fluent.DefaultLocaleIs', 'The default locale is') . ' ' . $localeNames[Fluent::default_locale()];
+
+        $fields->unshift(
+            LiteralField::create(
+                'CurrentLocaleMessage',
+                sprintf(
+                    '<p class="message %s">' . _t('Fluent.EditingIn', 'Please note: You are editing in') . ' %s. %s.</p>',
+                    $messageClass,
+                    $localeNames[Fluent::current_locale()],
+                    $message
+                )
+            )
+        );
     }
 
     // </editor-fold>

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -7,3 +7,6 @@ en:
     LocaleFilterDescription: 'Check a locale to show this item on that locale'
     LocaleMenuFilterDescription: 'Select the locales where this item is visible in the menu'
     TABLOCALES: Locales
+    DefaultLocale: 'This is the default locale'
+    DefaultLocaleIs: 'The default locale is'
+    EditingIn: 'Please note: You are editing in'


### PR DESCRIPTION
Uses a success message state for the default locale, or a notice state for a non-default locale.
Is translatable.

Default locale:

![image](https://cloud.githubusercontent.com/assets/5170590/19257601/58133e20-8fcd-11e6-8114-4e18154ec36e.png)

Non-default locale:

![image](https://cloud.githubusercontent.com/assets/5170590/19257610/64874bb0-8fcd-11e6-80da-ca2a387344f0.png)

Resolves #221