### PR TITLE
Fix addLocaleIndicatorMessage method to only add locale message once.

### DIFF
--- a/code/extensions/FluentExtension.php
+++ b/code/extensions/FluentExtension.php
@@ -821,11 +821,16 @@ class FluentExtension extends DataExtension
      * Adds a UI message to indicate whether you're editing in the default locale or not
      *
      * @param  FieldList $fields
-     * @return self
+     * @return $this
      */
     protected function addLocaleIndicatorMessage(FieldList $fields)
     {
         if (Fluent::config()->disable_current_locale_message) {
+            return $this;
+        }
+
+        // If the field is already present, don't add it a second time
+        if ($fields->fieldByName('CurrentLocaleMessage')) {
             return $this;
         }
 
@@ -847,6 +852,8 @@ class FluentExtension extends DataExtension
                 )
             )
         );
+
+        return $this;
     }
 
     // </editor-fold>


### PR DESCRIPTION
Fixes an issue that was introduced with #221 
When the `updateCMSFields` extension hook is called multiple times (eg. once in a base-class and once in a superclass), the message would be added for every `extend` call.

This PR introduces a check that ensures that the message only gets added once.
Also made the method API more consistent.