### PR TITLE
Save null instead of the string literal when resetting to a default value from another locale

### DIFF
--- a/code/extensions/FluentExtension.php
+++ b/code/extensions/FluentExtension.php
@@ -740,6 +740,15 @@ class FluentExtension extends DataExtension
                     if (!empty($updates['fields'][$defaultField]) || $this->isFieldNullable($field)) {
                         $updates['fields'][$field] = $updates['fields'][$defaultField];
                     }
+
+
+                    // If the localised field has been reset to the default value (i.e. they're the same value)
+                    // we should store it as null to allow change transparency from the default locale in future.
+                    if ((!empty($updates['fields'][$defaultField]))
+                        && ($updates['fields'][$updateField] === $updates['fields'][$defaultField])
+                    ) {
+                        $updates['fields'][$updateField] = null;
+                    }
                 }
             }
 

--- a/code/extensions/FluentExtension.php
+++ b/code/extensions/FluentExtension.php
@@ -745,7 +745,7 @@ class FluentExtension extends DataExtension
                     // If the localised field has been reset to the default value (i.e. they're the same value)
                     // we should store it as null to allow change transparency from the default locale in future.
                     if ((!empty($updates['fields'][$defaultField]))
-                        && (!$this->isFieldNullable($updateField))
+                        && (!$this->isFieldNullable($defaultField))
                         && ($updates['fields'][$updateField] === $updates['fields'][$defaultField])
                     ) {
                         $updates['fields'][$updateField] = null;
@@ -831,7 +831,7 @@ class FluentExtension extends DataExtension
      * Adds a UI message to indicate whether you're editing in the default locale or not
      *
      * @param  FieldList $fields
-     * @return self
+     * @return $this
      */
     protected function addLocaleIndicatorMessage(FieldList $fields)
     {

--- a/code/extensions/FluentExtension.php
+++ b/code/extensions/FluentExtension.php
@@ -745,6 +745,7 @@ class FluentExtension extends DataExtension
                     // If the localised field has been reset to the default value (i.e. they're the same value)
                     // we should store it as null to allow change transparency from the default locale in future.
                     if ((!empty($updates['fields'][$defaultField]))
+                        && (!$this->isFieldNullable($updateField))
                         && ($updates['fields'][$updateField] === $updates['fields'][$defaultField])
                     ) {
                         $updates['fields'][$updateField] = null;
@@ -830,16 +831,14 @@ class FluentExtension extends DataExtension
      * Adds a UI message to indicate whether you're editing in the default locale or not
      *
      * @param  FieldList $fields
-     * @return $this
+     * @return self
      */
     protected function addLocaleIndicatorMessage(FieldList $fields)
     {
-        if (Fluent::config()->disable_current_locale_message) {
-            return $this;
-        }
-
-        // If the field is already present, don't add it a second time
-        if ($fields->fieldByName('CurrentLocaleMessage')) {
+        if ((Fluent::config()->disable_current_locale_message)
+            // If the field is already present, don't add it a second time
+            || ($fields->fieldByName('CurrentLocaleMessage'))
+        ) {
             return $this;
         }
 

--- a/tests/FluentTest.php
+++ b/tests/FluentTest.php
@@ -1021,7 +1021,7 @@ class FluentTest extends SapphireTest
         // Publish this record in the custom locale, setting one of the fields to show it will not return default
         Fluent::with_locale('es_ES', function () use ($id) {
             $page = Versioned::get_one_by_stage("SiteTree", "Stage", "\"SiteTree\".\"ID\" = $id");
-            $page->MenuTitle - 'Spanish Custom Title';
+            $page->MenuTitle = 'Spanish Custom Title';
             $page->doPublish();
         });
 

--- a/tests/FluentTest.php
+++ b/tests/FluentTest.php
@@ -913,12 +913,12 @@ class FluentTest extends SapphireTest
         $item2->Title = 'English 2';
         $item2->write();
 
-        // check alternate locale title unchanged
+        // check alternate locale title reflects the default locale value
         $es2Title = Fluent::with_locale('es_ES', function () use ($item2ID) {
             $item2 = FluentTest_TranslatedObject::get()->byId($item2ID);
             return $item2->Title;
         });
-        $this->assertEquals($es2Title, 'Spanish 2');
+        $this->assertEquals($es2Title, 'English 2');
 
         // Test that object selected in default locale has the recently changed title
         $item2 = FluentTest_TranslatedObject::get()->byId($item2ID);
@@ -1015,12 +1015,13 @@ class FluentTest extends SapphireTest
         // Save title in default locale
         $page = Versioned::get_one_by_stage("SiteTree", "Stage", "\"SiteTree\".\"ID\" = $id");
         $page->Title = 'Default Title';
-        $page->MenuTitle = 'Custom Title';
+        $page->MenuTitle = 'Default Custom Title';
         $page->write();
 
-        // Publish this record in the custom locale
+        // Publish this record in the custom locale, setting one of the fields to show it will not return default
         Fluent::with_locale('es_ES', function () use ($id) {
             $page = Versioned::get_one_by_stage("SiteTree", "Stage", "\"SiteTree\".\"ID\" = $id");
+            $page->MenuTitle - 'Spanish Custom Title';
             $page->doPublish();
         });
 
@@ -1029,15 +1030,15 @@ class FluentTest extends SapphireTest
         // Check the live record has the correct title in the default locale
         $page = Versioned::get_one_by_stage("SiteTree", "Live", "\"SiteTree\".\"ID\" = $id");
         $this->assertEquals('Default Title', $page->Title);
-        $this->assertEquals('Custom Title', $page->MenuTitle);
+        $this->assertEquals('Default Custom Title', $page->MenuTitle);
 
         // Check the live record has the correct title in the custom locale
         $record = Fluent::with_locale('es_ES', function () use ($id) {
             $page = Versioned::get_one_by_stage("SiteTree", "Live", "\"SiteTree\".\"ID\" = $id");
             return $page->toMap();
         });
-        $this->assertEquals('ES Title', $record['Title']);
-        $this->assertEquals('ES Title', $record['MenuTitle']);
+        $this->assertEquals('Default Title', $record['Title']);
+        $this->assertEquals('Spanish Custom Title', $record['MenuTitle']);
     }
 
     /*
@@ -1070,11 +1071,11 @@ class FluentTest extends SapphireTest
 
         // Check that the necessary fields are assigned
         $this->assertEquals('es title', $row['Title']);
-        $this->assertEquals('es title', $row['Title_es_ES']);
-        $this->assertEquals('es title', $row['Title_fr_CA']);
+        $this->assertNull($row['Title_es_ES']);
+        $this->assertEquals('es title', $row['Title_fr_CA']); // the default locale is still duplicated
         $this->assertEmpty($row['Title_en_NZ']);
         $this->assertEquals('es description', $row['Description']);
-        $this->assertEquals('es description', $row['Description_es_ES']);
+        $this->assertNull($row['Description_es_ES']);
         $this->assertEquals('es description', $row['Description_fr_CA']);
         $this->assertEmpty($row['Description_en_NZ']);
 
@@ -1089,11 +1090,11 @@ class FluentTest extends SapphireTest
         // Check that the necessary fields are assigned
         $row = DB::query(sprintf("SELECT * FROM \"FluentTest_TranslatedObject\" WHERE \"ID\" = %d", $recordID))->first();
         $this->assertEquals('new ca title', $row['Title']);
-        $this->assertEquals('es title', $row['Title_es_ES']);
+        $this->assertNull($row['Title_es_ES']);
         $this->assertEquals('new ca title', $row['Title_fr_CA']);
         $this->assertEmpty($row['Title_en_NZ']);
         $this->assertEquals('es description', $row['Description']);
-        $this->assertEquals('es description', $row['Description_es_ES']);
+        $this->assertNull($row['Description_es_ES']);
         $this->assertEquals('es description', $row['Description_fr_CA']);
         $this->assertEmpty($row['Description_en_NZ']);
 
@@ -1108,11 +1109,11 @@ class FluentTest extends SapphireTest
         // Check that the necessary fields are assigned
         $row = DB::query(sprintf("SELECT * FROM \"FluentTest_TranslatedObject\" WHERE \"ID\" = %d", $recordID))->first();
         $this->assertEquals('new ca title', $row['Title']);
-        $this->assertEquals('es title', $row['Title_es_ES']);
+        $this->assertNull($row['Title_es_ES']);
         $this->assertEquals('new ca title', $row['Title_fr_CA']);
         $this->assertEquals('nz title', $row['Title_en_NZ']);
         $this->assertEquals('es description', $row['Description']);
-        $this->assertEquals('es description', $row['Description_es_ES']);
+        $this->assertNull($row['Description_es_ES']);
         $this->assertEquals('es description', $row['Description_fr_CA']);
         $this->assertEquals('nz description', $row['Description_en_NZ']);
     }


### PR DESCRIPTION
This ensures that underlying changes at the default locale will still come through at non-standard locales, as they would when you first create a DataObject.

Resolves #238 