### PR TITLE
NEW Ensure locale detection priority is honoured for homepage and non-homepage routes

### DIFF
--- a/src/Control/LocaleAdmin.php
+++ b/src/Control/LocaleAdmin.php
@@ -32,7 +32,7 @@ class LocaleAdmin extends ModelAdmin
             parent::getClientConfig(),
             [
                 'fluent' => [
-                    'locales' => array_map(function(Locale $locale) {
+                    'locales' => array_map(function (Locale $locale) {
                         return [
                             'code' => $locale->getLocale(),
                             'title' => $locale->getTitle(),

--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -84,8 +84,8 @@ class DetectLocaleMiddleware implements HTTPMiddleware
             $locale = $this->getPersistLocale($request);
         }
 
-        // Check for locale in browser headers
-        if (empty($locale)) {
+        // Home page only: check for locale in browser headers
+        if (empty($locale) && $request->getURL() === '') {
             $locale = LocaleDetector::singleton()->detectBrowserLocale($request);
         }
 

--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -59,8 +59,10 @@ class DetectLocaleMiddleware implements HTTPMiddleware
             $locale = $this->getLocale($request);
 
             $state->setLocale($locale);
-            $this->setPersistLocale($request, $locale);
         }
+
+        // Always persist the current locale
+        $this->setPersistLocale($request, $state->getLocale());
 
         return $delegate($request);
     }

--- a/src/Model/Locale.php
+++ b/src/Model/Locale.php
@@ -209,4 +209,15 @@ DESC
         }
         return Locale::getCached()->filter('Locale', $locale)->first();
     }
+
+    /**
+     * Returns whether the given locale matches the current Locale object
+     *
+     * @param  string $locale E.g. en_NZ, en-NZ, en-nz-1990
+     * @return bool
+     */
+    public function isLocale($locale)
+    {
+        return stripos(str_replace('_', '-', $locale), str_replace('_', '-', $this->Locale)) === 0;
+    }
 }

--- a/src/State/LocaleDetector.php
+++ b/src/State/LocaleDetector.php
@@ -105,9 +105,10 @@ class LocaleDetector
         // Check each requested locale against loaded locales
         foreach ($prioritisedLocales as $priority => $parsedLocales) {
             foreach ($parsedLocales as $browserLocale) {
-                foreach ($this->getLocales($currentDomain) as $locale) {
-                    if (stripos(preg_replace('/_/', '-', $locale), $browserLocale) === 0) {
-                        return $locale;
+                foreach ($this->getLocales($currentDomain) as $localeObj) {
+                    /** @var Locale $localeObj */
+                    if (stripos(preg_replace('/_/', '-', $localeObj->Locale), $browserLocale) === 0) {
+                        return $localeObj->Locale;
                     }
                 }
             }
@@ -156,7 +157,7 @@ class LocaleDetector
             return $domain->Locales();
         }
 
-        return Domain::getCached();
+        return Locale::getCached();
     }
 
     /**

--- a/src/State/LocaleDetector.php
+++ b/src/State/LocaleDetector.php
@@ -107,7 +107,7 @@ class LocaleDetector
             foreach ($parsedLocales as $browserLocale) {
                 foreach ($this->getLocales($currentDomain) as $localeObj) {
                     /** @var Locale $localeObj */
-                    if (stripos(preg_replace('/_/', '-', $localeObj->Locale), $browserLocale) === 0) {
+                    if ($localeObj->isLocale($browserLocale)) {
                         return $localeObj->Locale;
                     }
                 }

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.php
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.php
@@ -2,22 +2,79 @@
 
 namespace TractorCow\Fluent\Middleware;
 
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
+use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Middleware\DetectLocaleMiddleware;
 use TractorCow\Fluent\State\FluentState;
 
 class DetectLocaleMiddlewareTest extends SapphireTest
 {
+    protected static $fixture_file = 'DetectLocaleMiddlewareTest.yml';
+
+    /**
+     * @var DetectLocaleMiddleware
+     */
+    protected $middleware;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->middleware = new DetectLocaleMiddleware;
+
+        Config::modify()->set(FluentDirectorExtension::class, 'query_param', 'l');
+    }
+
     public function testGetPersistKey()
     {
-        $middleware = new DetectLocaleMiddleware;
-        $this->assertSame('foo', $middleware->getPersistKey('foo'));
+        $this->assertSame('foo', $this->middleware->getPersistKey('foo'));
 
         $state = FluentState::singleton();
         $state->setIsFrontend(true);
-        $this->assertSame('FluentLocale', $middleware->getPersistKey());
+        $this->assertSame('FluentLocale', $this->middleware->getPersistKey());
 
         $state->setIsFrontend(false);
-        $this->assertSame('FluentLocale_CMS', $middleware->getPersistKey());
+        $this->assertSame('FluentLocale_CMS', $this->middleware->getPersistKey());
+    }
+
+    /**
+     * @dataProvider localePriorityProvider
+     */
+    public function testGetLocalePriority($url, $routeParams, $queryParams, $persisted, $header, $expected)
+    {
+        $request = new HTTPRequest('GET', $url, $queryParams);
+        $request->setRouteParams($routeParams);
+        $request->setSession(Controller::curr()->getRequest()->getSession());
+        $this->middleware->setPersistLocale($request, null);
+
+        if ($persisted) {
+            $this->middleware->setPersistLocale($request, $persisted);
+        }
+        if ($header) {
+            $request->addHeader('Accept-Language', $header);
+        }
+
+        $this->assertSame($expected, $this->middleware->getLocale($request));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function localePriorityProvider()
+    {
+        return [
+            // First priority: controller routing params
+            ['/nz/foo', ['l' => 'en_NZ'], ['l' => 'en_AU'], 'fr_FR', 'es-US', 'en_NZ'],
+            // Second priority: request params
+            ['/foo', [], ['l' => 'en_AU'], 'fr_FR', 'es-US', 'en_AU'],
+            // Third priority: persisted locale
+            ['/foo', [], [], 'fr_FR', 'es-US', 'fr_FR'],
+            // Default to the default locale when not on the homepage
+            ['/foo', [], [], null, 'es-US', 'es_ES'],
+            // Home page only - fourth priority is request header
+            ['/', [], [], null, 'es-US', 'es_US'],
+        ];
     }
 }

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.php
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.php
@@ -77,4 +77,21 @@ class DetectLocaleMiddlewareTest extends SapphireTest
             ['/', [], [], null, 'es-US', 'es_US'],
         ];
     }
+
+    public function testLocaleIsAlwaysPersistedEvenIfNotSetByTheMiddleware()
+    {
+        $request = new HTTPRequest('GET', '/');
+        FluentState::singleton()->setLocale('dummy');
+
+        $middleware = $this->getMockBuilder(DetectLocaleMiddleware::class)
+            ->setMethods(['getLocale', 'setPersistLocale'])
+            ->getMock();
+
+        $middleware->expects($this->never())->method('getLocale');
+        $middleware->expects($this->once())->method('setPersistLocale')->with($request, 'dummy');
+
+        $middleware->process($request, function () {
+            // no-op
+        });
+    }
 }

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.yml
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.yml
@@ -1,0 +1,16 @@
+TractorCow\Fluent\Model\Locale:
+  en_NZ:
+    Locale: en_NZ
+    URLSegment: nz
+  en_AU:
+    Locale: en_AU
+    URLSegment: au
+  fr_FR:
+    Locale: fr_FR
+    URLSegment: fr
+  es_US:
+    Locale: es_US
+  es_ES:
+    Locale: es_ES
+    URLSegment: es
+    IsDefault: 1

--- a/tests/php/Model/LocaleTest.php
+++ b/tests/php/Model/LocaleTest.php
@@ -28,4 +28,29 @@ class LocaleTest extends SapphireTest
         $this->assertInstanceOf(Locale::class, $result);
         $this->assertSame('es_US', $result->Locale, 'First Locale in Domain with IsDefault true is returned');
     }
+
+    /**
+     * @dataProvider isLocaleProvider
+     */
+    public function testIsLocale($locale, $input, $expected)
+    {
+        $localeObj = Locale::create()->setField('Locale', $locale);
+        $this->assertSame($expected, $localeObj->isLocale($input));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function isLocaleProvider()
+    {
+        return [
+            ['en_NZ', 'en_NZ', true],
+            ['en_nz', 'en-NZ', true],
+            ['en-NZ', 'en_nz', true],
+            ['en-nz', 'en-nz', true],
+            ['en_NZ', 'en-NZ-1990', true],
+            ['en_NZ', 'en_AU', false],
+            ['en_NZ', 'fr-fr-1990', false],
+        ];
+    }
 }


### PR DESCRIPTION
Order should be 1) route param, 2) request param, 3) persisted locale and if home page then 4) language header.