### PR TITLE
BUG Ensure that unpublish affects only the current locale

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -7,3 +7,6 @@ SilverStripe\CMS\Model\SiteTree:
 SilverStripe\Admin\LeftAndMain:
   extensions:
     FluentLeftAndMainExtension: TractorCow\Fluent\Extension\FluentLeftAndMainExtension
+SilverStripe\Versioned\ChangeSetItem:
+  extensions:
+    FluentChangesExtension: TractorCow\Fluent\Extension\FluentChangesExtension

--- a/src/Extension/FluentChangesExtension.php
+++ b/src/Extension/FluentChangesExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace TractorCow\Fluent\Extension;
+
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Versioned\ChangeSetItem;
+
+/**
+ * Adds locale-specific extensions to ChangeSet
+ */
+class FluentChangesExtension extends DataExtension
+{
+    public function updateChangeType(&$type, $draftVersion, $liveVersion)
+    {
+        if ($type !== ChangeSetItem::CHANGE_NONE) {
+            return;
+        }
+
+        // Mark any fluent object as modified if otherwise treated as null
+        /** @var ChangeSetItem $owner */
+        $owner = $this->owner;
+        foreach ($owner->Object()->getExtensionInstances() as $extension) {
+            if ($extension instanceof FluentExtension) {
+                $type = ChangeSetItem::CHANGE_MODIFIED;
+                return;
+            }
+        }
+    }
+}

--- a/src/Extension/FluentVersionedExtension.php
+++ b/src/Extension/FluentVersionedExtension.php
@@ -218,4 +218,21 @@ class FluentVersionedExtension extends FluentExtension
             }
         }
     }
+
+    /**
+     * Decorate table to delete with _Live suffix as necessary
+     *
+     * @param string $tableName
+     * @param string $locale
+     * @return string
+     */
+    protected function getDeleteTableTarget($tableName, $locale = '')
+    {
+        // Rewrite to _Live when deleting from live / unpublishing
+        $table = parent::getDeleteTableTarget($tableName, $locale);
+        if (Versioned::get_stage() === Versioned::LIVE) {
+            $table .= '_' . self::SUFFIX_LIVE;
+        }
+        return $table;
+    }
 }


### PR DESCRIPTION
This required a few core extension points (won't work on beta4, but will on rc1).

When we unpublish this ensures that the current locale is unpublished, but no other locales.

The "root" table is always unpublished after the last localised version is unpublished.

cc @robbieaverill 