### PR TITLE
Tests for FluentSiteTreeExtension::Link()

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -763,4 +763,14 @@ class FluentExtension extends DataExtension
             }
         });
     }
+
+    /**
+     * Ensure has_one cache is segmented by locale
+     *
+     * @return string
+     */
+    public function cacheKeyComponent()
+    {
+        return 'fluentlocale-' . FluentState::singleton()->getLocale();
+    }
 }

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -5,6 +5,7 @@ namespace TractorCow\Fluent\Extension;
 use SilverStripe\CMS\Controllers\RootURLController;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
+use TractorCow\Fluent\State\FluentState;
 
 /**
  * Fluent extension for SiteTree
@@ -83,6 +84,11 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
         // Don't rewrite outside of domain mode
         $domain = $localeObj->getDomain();
         if (!$domain) {
+            return;
+        }
+
+        // Don't need to prepend domain if on the same domain
+        if (FluentState::singleton()->getDomain() === $domain->Domain) {
             return;
         }
 

--- a/tests/php/Extension/FluentExtensionTest.php
+++ b/tests/php/Extension/FluentExtensionTest.php
@@ -4,15 +4,16 @@ namespace TractorCow\Fluent\Tests\Extension;
 
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
-use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
 use TractorCow\Fluent\State\FluentState;
 use TractorCow\Fluent\Tests\Extension\Stub\FluentStubObject;
 
 class FluentExtensionTest extends SapphireTest
 {
     protected static $required_extensions = [
-        SiteTree::class => [FluentExtension::class],
-        FluentStubObject::class => [FluentExtension::class],
+        SiteTree::class => [
+            FluentSiteTreeExtension::class,
+        ],
     ];
 
     public function testFluentLocaleAndFrontendAreAddedToDataQuery()
@@ -21,7 +22,6 @@ class FluentExtensionTest extends SapphireTest
             ->setLocale('test')
             ->setIsFrontend(true);
 
-        /** @var \SilverStripe\ORM\DataQuery $query */
         $query = SiteTree::get()->dataQuery();
         $this->assertSame('test', $query->getQueryParam('Fluent.Locale'));
         $this->assertTrue($query->getQueryParam('Fluent.IsFrontend'));
@@ -29,7 +29,20 @@ class FluentExtensionTest extends SapphireTest
 
     public function testGetLocalisedTable()
     {
-        $this->assertSame('SiteTree_Localised', (new SiteTree)->getLocalisedTable('SiteTree'));
-        $this->assertSame('SiteTree_Localised_FR', (new SiteTree)->getLocalisedTable('SiteTree', 'FR'));
+        /** @var SiteTree|FluentSiteTreeExtension $page */
+        $page = new SiteTree;
+        $this->assertSame('SiteTree_Localised', $page->getLocalisedTable('SiteTree'));
+        $this->assertSame('SiteTree_Localised_FR', $page->getLocalisedTable('SiteTree', 'FR'));
+    }
+
+    public function testGetLinkingMode()
+    {
+        // Does not have a canViewInLocale method, locale is not current
+        $stub = new FluentStubObject();
+        $this->assertSame('link', $stub->getLinkingMode('foo'));
+
+        // Does not have a canViewInLocale method, locale is current
+        FluentState::singleton()->setLocale('foo');
+        $this->assertSame('current', $stub->getLinkingMode('foo'));
     }
 }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -10,29 +10,30 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;
 use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
-use TractorCow\Fluent\Model\Locale;
-use TractorCow\Fluent\State\FluentState;
-use TractorCow\Fluent\Tests\Extension\Stub\FluentStubObject;
 
 class FluentSiteTreeExtensionTest extends SapphireTest
 {
     protected static $fixture_file = 'FluentSiteTreeExtensionTest.yml';
 
     protected static $required_extensions = [
-        SiteTree::class => [FluentSiteTreeExtension::class],
-        FluentStubObject::class => [FluentSiteTreeExtension::class],
+        SiteTree::class => [
+            FluentSiteTreeExtension::class,
+        ],
     ];
 
     protected function setUp()
     {
         parent::setUp();
 
-        Config::inst()->update(Director::class, 'alternate_base_url', 'http://mocked');
+        Config::modify()
+            ->set(Director::class, 'alternate_base_url', 'http://mocked');
     }
 
     public function testGetLocaleInformation()
     {
-        $result = $this->objFromFixture(Page::class, 'nz-page')->LocaleInformation('en_NZ');
+        /** @var Page|FluentSiteTreeExtension $page */
+        $page = $this->objFromFixture(Page::class, 'nz-page');
+        $result = $page->LocaleInformation('en_NZ');
 
         $this->assertInstanceOf(ArrayData::class, $result);
         $this->assertEquals([
@@ -50,23 +51,15 @@ class FluentSiteTreeExtensionTest extends SapphireTest
 
     public function testGetLocales()
     {
-        $result = $this->objFromFixture(Page::class, 'nz-page')->Locales();
+        /** @var Page|FluentSiteTreeExtension $page */
+        $page = $this->objFromFixture(Page::class, 'nz-page');
+        $result = $page->Locales();
 
         $this->assertInstanceOf(ArrayList::class, $result);
         $this->assertCount(2, $result);
-        $this->assertDOSEquals([
+        $this->assertListEquals([
             ['Locale' => 'en_NZ'],
             ['Locale' => 'de_DE'],
         ], $result);
-    }
-
-    public function testGetLinkingMode()
-    {
-        // Does not have a canViewInLocale method, locale is not current
-        $this->assertSame('link', (new FluentStubObject)->getLinkingMode('foo'));
-
-        // Does not have a canViewInLocale method, locale is current
-        FluentState::singleton()->setLocale('foo');
-        $this->assertSame('current', (new FluentStubObject)->getLinkingMode('foo'));
     }
 }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -9,7 +9,11 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;
+use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
+use TractorCow\Fluent\Model\Domain;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
 
 class FluentSiteTreeExtensionTest extends SapphireTest
 {
@@ -24,9 +28,16 @@ class FluentSiteTreeExtensionTest extends SapphireTest
     protected function setUp()
     {
         parent::setUp();
-
         Config::modify()
-            ->set(Director::class, 'alternate_base_url', 'http://mocked');
+            ->set(Director::class, 'alternate_base_url', 'http://mocked')
+            ->set(FluentDirectorExtension::class, 'disable_default_prefix', false);
+
+        // Clear cache
+        Locale::clearCached();
+        Domain::clearCached();
+        FluentState::singleton()
+            ->setLocale('de_DE')
+            ->setIsDomainMode(false);
     }
 
     public function testGetLocaleInformation()
@@ -56,10 +67,87 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         $result = $page->Locales();
 
         $this->assertInstanceOf(ArrayList::class, $result);
-        $this->assertCount(2, $result);
+        $this->assertCount(4, $result);
         $this->assertListEquals([
             ['Locale' => 'en_NZ'],
             ['Locale' => 'de_DE'],
+            ['Locale' => 'en_US'],
+            ['Locale' => 'es_ES'],
         ], $result);
+    }
+
+    /**
+     * Tests for url generation
+     *
+     * @return array list of tests with values:
+     *  - domain (or false for non-domain mode)
+     *  - locale
+     *  - disable_default_prefix flag
+     *  - page id
+     *  - expected link
+     */
+    public function provideURLTests()
+    {
+        return [
+            // Non-domain tests
+            [null, 'de_DE', false, 'home', '/'],
+            [null, 'de_DE', false, 'about', '/german/about-us/'],
+            [null, 'de_DE', false, 'staff', '/german/about-us/my-staff/'],
+            // Since de_DE is the only locale on the www.example.de domain, ensure that the locale
+            // isn't unnecessarily added to the link.
+            // In this case disable_default_prefix is ignored
+            // See https://github.com/tractorcow/silverstripe-fluent/issues/75
+            ['www.example.de', 'de_DE', false, 'home', '/'],
+            ['www.example.de', 'de_DE', false, 'about', '/about-us/'],
+            ['www.example.de', 'de_DE', false, 'staff', '/about-us/my-staff/'],
+
+            // Test domains with multiple locales
+            //  - es_ES non default locale
+            ['www.example.com', 'es_ES', false, 'home', '/es_ES/'],
+            ['www.example.com', 'es_ES', false, 'about', '/es_ES/about-us/'],
+            ['www.example.com', 'es_ES', false, 'staff', '/es_ES/about-us/my-staff/'],
+            //  - en_US default locale
+            ['www.example.com', 'en_US', false, 'home', '/'],
+            ['www.example.com', 'en_US', false, 'about', '/usa/about-us/'],
+            ['www.example.com', 'en_US', false, 'staff', '/usa/about-us/my-staff/'],
+            //  - en_US default locale, but with disable_default_prefix on
+            ['www.example.com', 'en_US', true, 'home', '/'],
+            ['www.example.com', 'en_US', true, 'about', '/about-us/'],
+            ['www.example.com', 'en_US', true, 'staff', '/about-us/my-staff/'],
+
+            // Test cross-domain links include the opposing domain
+            // - to default locale
+            ['www.example.de', 'en_US', true, 'home', 'http://www.example.com/'],
+            ['www.example.de', 'en_US', true, 'staff', 'http://www.example.com/about-us/my-staff/'],
+            // - to non defalut locale
+            ['www.example.de', 'es_ES', true, 'home', 'http://www.example.com/es_ES/'],
+            ['www.example.de', 'es_ES', true, 'staff', 'http://www.example.com/es_ES/about-us/my-staff/'],
+        ];
+    }
+
+    /**
+     * Test that URLS for pages are generated correctly
+     *
+     * @dataProvider provideURLTests
+     * @param string $domain
+     * @param string $locale
+     * @param bool $prefixDisabled
+     * @param string $pageName
+     * @param string $url
+     */
+    public function testFluentURLs($domain, $locale, $prefixDisabled, $pageName, $url)
+    {
+        // Set state
+        FluentState::singleton()
+            ->setLocale($locale)
+            ->setDomain($domain)
+            ->setIsDomainMode(!empty($domain));
+        // Set url generation option
+        Config::modify()
+            ->set(FluentDirectorExtension::class, 'disable_default_prefix', $prefixDisabled);
+
+        /** @var Page|FluentSiteTreeExtension $page */
+        $page = $this->objFromFixture('Page', $pageName);
+        $this->assertEquals($url, $page->Link());
     }
 }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.yml
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.yml
@@ -1,14 +1,47 @@
 TractorCow\Fluent\Model\Locale:
   nz:
     Locale: en_NZ
-    Title: English (New Zealand)
+    Title: 'English (New Zealand)'
     URLSegment: newzealand
+  us:
+    Locale: en_US
+    Title: 'English (US)'
+    URLSegment: usa
   de:
     Locale: de_DE
     Title: German
     URLSegment: german
+  es:
+    Locale: es_ES
+    Title: Spanish
+
+TractorCow\Fluent\Model\Domain:
+  com:
+    Domain: www.example.com
+    Locales:
+      - =>TractorCow\Fluent\Model\Locale.es
+      - =>TractorCow\Fluent\Model\Locale.us
+    DefaultLocale: =>TractorCow\Fluent\Model\Locale.us
+  de:
+    Domain: www.example.de
+    Locales:
+      - =>TractorCow\Fluent\Model\Locale.de
+  conz:
+    Domain: www.example.co.nz
+    Locales:
+      - =>TractorCow\Fluent\Model\Locale.nz
 
 Page:
   nz-page:
     Title: A Page
     URLSegment: a-page
+  home:
+    Title: Home
+    URLSegment: home
+  about:
+    Title: About Us
+    URLSegment: about-us
+  staff:
+    Title: Staff
+    URLSegment: my-staff
+    Parent: =>Page.about

--- a/tests/php/Extension/Stub/FluentStubObject.php
+++ b/tests/php/Extension/Stub/FluentStubObject.php
@@ -2,15 +2,16 @@
 
 namespace TractorCow\Fluent\Tests\Extension\Stub;
 
-use SilverStripe\Core\Extensible;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentExtension;
 
-class FluentStubObject implements TestOnly
+/**
+ * @mixin FluentExtension
+ */
+class FluentStubObject extends DataObject implements TestOnly
 {
-    use Extensible;
-
-    public function __construct()
-    {
-        $this->constructExtensions();
-    }
+    private static $extensions = [
+        FluentExtension::class,
+    ];
 }

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.php
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.php
@@ -2,11 +2,13 @@
 
 namespace TractorCow\Fluent\Tests\Middleware;
 
+use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
+use TractorCow\Fluent\Middleware\DetectLocaleMiddleware;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
@@ -16,7 +18,7 @@ class DetectLocaleMiddlewareTest extends SapphireTest
     protected static $fixture_file = 'DetectLocaleMiddlewareTest.yml';
 
     /**
-     * @var DetectLocaleMiddleware
+     * @var Stub\DetectLocaleMiddlewareSpy
      */
     protected $middleware;
 
@@ -47,6 +49,12 @@ class DetectLocaleMiddlewareTest extends SapphireTest
 
     /**
      * @dataProvider localePriorityProvider
+     * @param string $url
+     * @param array $routeParams
+     * @param array $queryParams
+     * @param bool $persisted
+     * @param string $header
+     * @param string $expected
      */
     public function testGetLocalePriority($url, $routeParams, $queryParams, $persisted, $header, $expected)
     {
@@ -89,7 +97,8 @@ class DetectLocaleMiddlewareTest extends SapphireTest
         $request = new HTTPRequest('GET', '/');
         FluentState::singleton()->setLocale('dummy');
 
-        $middleware = $this->getMockBuilder(Stub\DetectLocaleMiddlewareSpy::class)
+        /** @var DetectLocaleMiddleware|PHPUnit_Framework_MockObject_MockObject $middleware */
+        $middleware = $this->getMockBuilder(DetectLocaleMiddleware::class)
             ->setMethods(['getLocale', 'setPersistLocale'])
             ->getMock();
 

--- a/tests/php/Middleware/InitStateMiddlewareTest.php
+++ b/tests/php/Middleware/InitStateMiddlewareTest.php
@@ -10,6 +10,8 @@ class InitStateMiddlewareTest extends SapphireTest
 {
     /**
      * @dataProvider isFrontendProvider
+     * @param string $url
+     * @param string $expected
      */
     public function testGetIsFrontend($url, $expected)
     {

--- a/tests/php/Middleware/Stub/DetectLocaleMiddlewareSpy.php
+++ b/tests/php/Middleware/Stub/DetectLocaleMiddlewareSpy.php
@@ -2,11 +2,16 @@
 
 namespace TractorCow\Fluent\Tests\Middleware\Stub;
 
+use SilverStripe\Control\HTTPRequest;
 use TractorCow\Fluent\Middleware\DetectLocaleMiddleware;
 use SilverStripe\Dev\TestOnly;
 
 /**
  * Opens up DetectLocaleMiddleware protected methods for unit testing
+ *
+ * @method string getPersistKey()
+ * @method $this setPersistLocale(HTTPRequest $request, $locale)
+ * @method string getLocale(HTTPRequest $request)
  */
 class DetectLocaleMiddlewareSpy extends DetectLocaleMiddleware implements TestOnly
 {

--- a/tests/php/Model/LocaleTest.php
+++ b/tests/php/Model/LocaleTest.php
@@ -3,6 +3,7 @@
 namespace TractorCow\Fluent\Tests\Model;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\CheckboxField;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
 use TractorCow\Fluent\State\FluentState;
@@ -116,7 +117,7 @@ class LocaleTest extends SapphireTest
     public function testGetSiblings()
     {
         $esUS = Locale::getByLocale('es_US');
-        $this->assertDOSEquals([
+        $this->assertListEquals([
             [ 'Locale' => 'es_US' ],
             [ 'Locale' => 'es_ES' ],
         ], $esUS->getSiblingLocales());
@@ -125,7 +126,7 @@ class LocaleTest extends SapphireTest
         FluentState::singleton()->setIsDomainMode(false);
 
         $esUS = Locale::getByLocale('es_US');
-        $this->assertDOSEquals([
+        $this->assertListEquals([
             [ 'Locale' => 'es_US' ],
             [ 'Locale' => 'es_ES' ],
             [ 'Locale' => 'en_NZ' ],
@@ -181,10 +182,9 @@ class LocaleTest extends SapphireTest
 
         $firstLocale = new Locale;
 
-        /** @var SilverStripe\Forms\FieldList $fields  */
         $fields = $firstLocale->getCMSFields();
 
-        /** @var SilverStripe\Forms\CheckboxField $checkbox */
+        /** @var CheckboxField $checkbox */
         $checkbox = $fields->fieldByName('Root.Main.IsGlobalDefault');
         $this->assertTrue((bool) $checkbox->Value());
     }

--- a/tests/php/Model/LocaleTest.php
+++ b/tests/php/Model/LocaleTest.php
@@ -53,6 +53,14 @@ class LocaleTest extends SapphireTest
         $this->assertSame('en_AU', $result2->Locale, 'First Locale in Domain with IsDefault true is returned');
     }
 
+    public function testGetDefaultWithCurrentDomainArgument()
+    {
+        // Get current default
+        $result = Locale::getDefault(true); // Should use fluent.co.nz current domain
+        $this->assertInstanceOf(Locale::class, $result);
+        $this->assertSame('en_AU', $result->Locale, 'First Locale in Domain with IsDefault true is returned');
+    }
+
     /**
      * @dataProvider isLocaleProvider
      * @param string $locale


### PR DESCRIPTION
Migrated from old 3 branch, along with various tests and cleanup to the (awesome) tests that are already there. :)

For @robbieaverill to review