### PR TITLE
Update scrutinizer build

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,5 +1,11 @@
 inherit: true
 
+build:
+  nodes:
+    analysis:
+      tests:
+        override: [php-scrutinizer-run]
+
 checks:
   php:
     code_rating: true


### PR DESCRIPTION
Fixes the issue caused by outdated composer version

```
    - silverstripe/vendor-plugin 1.0.1 requires composer-plugin-api ^1.1 -> no matching package found.

```