### PR TITLE
Add new config to determine frontend visibility of unpublished locales

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -110,6 +110,11 @@ class FluentExtension extends DataExtension
     protected $localisedFields = [];
 
     /**
+     * @var bool
+     */
+    private static $frontend_publish_required = true;
+
+    /**
      * Get list of fields that are localised
      *
      * @param string $class Class to get fields for (if parent)
@@ -282,7 +287,7 @@ class FluentExtension extends DataExtension
         }
 
         // On frontend only show if published in this specific locale
-        if (FluentState::singleton()->getIsFrontend()) {
+        if ($this->owner->config()->get('frontend_publish_required') && FluentState::singleton()->getIsFrontend()) {
             $joinAlias = $this->getLocalisedTable($this->owner->baseTable(), $locale->Locale);
             $where = "\"{$joinAlias}\".\"ID\" IS NOT NULL";
             $query->addWhereAny($where);


### PR DESCRIPTION
This addition makes the assumption that Fluent (by default) wants unpublished locales to inherit and display data based on its "Fallback", and for that data to be visible on the frontend (the same as current CMS/backend functionality). Unpublished locales are only hidden on the frontend when/if this config variable is set on the `owner` Object.

I would be more than happy to flip this assumption to hide on frontend by default if that is preferred.