### PR TITLE
Improve augmentSQL logic for FluentFilteredExtension. Fixes #307

### DIFF
--- a/tests/php/Extension/FluentFilteredExtensionTest.php
+++ b/tests/php/Extension/FluentFilteredExtensionTest.php
@@ -34,10 +34,19 @@ class FluentFilteredExtensionTest extends SapphireTest
             ->setIsDomainMode(false);
     }
 
-    public function testAugmentSQLFrontend()
+    public function testLocalisedFrontend()
     {
         FluentState::singleton()
             ->setLocale('en_NZ')
+            ->setIsFrontend(true);
+
+        $this->assertEquals(2, SiteTree::get()->count());
+    }
+
+    public function testFilteredFrontend()
+    {
+        FluentState::singleton()
+            ->setLocale('en_US')
             ->setIsFrontend(true);
 
         $this->assertEquals(1, SiteTree::get()->count());

--- a/tests/php/Extension/FluentFilteredExtensionTest.yml
+++ b/tests/php/Extension/FluentFilteredExtensionTest.yml
@@ -8,17 +8,18 @@ TractorCow\Fluent\Model\Locale:
     Title: 'English (US)'
     URLSegment: usa
 
+# US has been granted permission to inherit the content of the Home page. NZ has not.
 Page:
   home:
     Title: Home
     URLSegment: home
     FilteredLocales:
-      - '=>TractorCow\Fluent\Model\Locale.nz'
+      - '=>TractorCow\Fluent\Model\Locale.us'
   about:
     Title: About
     URLSegment: about
 
-# All pages are saved in each locale, but not all are visible in all locales
+# NZ cannot inherit content, but it has a Localised version of each Page.
 SiteTree_Localised:
   home:
     RecordID: =>Page.home


### PR DESCRIPTION
Related issue: https://github.com/tractorcow/silverstripe-fluent/issues/307

When viewing a page that has it's own (published) localisation, we shouldn't require that the same locale is also added into that Page's FilteredLocales records.

I've updated the tests to represent the different options now available.