### PR TITLE
FIX Use lowercase for page and locale in content author messages

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -40,9 +40,9 @@ en:
     LOCALEDRAFTEDHELP: 'Drafted locale edition has not been published'
     LOCALEINHERITEDSHORT: 'Inherited'
     LOCALEINHERITEDHELP: 'Page is inherited from fallback locale'
-    LOCALESTATUSINHERITED: 'Content for this Page is being inherited from another Locale. If you wish you make an independent copy of this Page, please use one of the "Copy" actions provided.'
-    LOCALESTATUSDRAFT: 'A draft has been created for this Locale, however, published content is still being inherited from another Locale. To publish this content for this Locale, use the "Save & publish" action provided.'
+    LOCALESTATUSINHERITED: 'Content for this page is being inherited from another locale. If you wish you make an independent copy of this page, please use one of the "Copy" actions provided.'
+    LOCALESTATUSDRAFT: 'A draft has been created for this locale, however, published content is still being inherited from another locale. To publish this content for this locale, use the "Save & publish" action provided.'
   TractorCow\Fluent\Extension\FluentFilteredExtension:
-    FILTERED_LOCALES: 'Display in the following Locales'
+    FILTERED_LOCALES: 'Display in the following locales'
     LOCALEFILTEREDSHORT: 'Filtered'
-    LOCALEFILTEREDHELP: 'This Page is not visible in this Locale'
+    LOCALEFILTEREDHELP: 'This page is not visible in this locale'

--- a/src/Extension/FluentFilteredExtension.php
+++ b/src/Extension/FluentFilteredExtension.php
@@ -49,7 +49,7 @@ class FluentFilteredExtension extends DataExtension
             'Root.Locales',
             GridField::create(
                 'FilteredLocales',
-                _t(__CLASS__.'.FILTERED_LOCALES', 'Display in the following Locales'),
+                _t(__CLASS__.'.FILTERED_LOCALES', 'Display in the following locales'),
                 $this->owner->FilteredLocales(),
                 $config
             )
@@ -78,7 +78,7 @@ class FluentFilteredExtension extends DataExtension
         // Add new status flag for "not visible".
         $flags['fluentfiltered'] = array(
             'text' => _t(__CLASS__ . '.LOCALEFILTEREDSHORT', 'Filtered'),
-            'title' => _t(__CLASS__ . '.LOCALEFILTEREDHELP', 'This Page is not visible in this Locale')
+            'title' => _t(__CLASS__ . '.LOCALEFILTEREDHELP', 'This page is not visible in this locale')
         );
     }
 

--- a/src/Extension/FluentSiteTreeExtension.php
+++ b/src/Extension/FluentSiteTreeExtension.php
@@ -197,14 +197,14 @@ class FluentSiteTreeExtension extends FluentVersionedExtension
         if (!$this->isDraftedInLocale()) {
             $message = _t(
                 __CLASS__ . 'LOCALESTATUSINHERITED',
-                'Content for this Page is being inherited from another Locale. If you wish you make an independent copy
-                of this Page, please use one of the "Copy" actions provided.'
+                'Content for this page is being inherited from another locale. If you wish you make an independent copy
+                of this page, please use one of the "Copy" actions provided.'
             );
         } else {
             $message = _t(
                 __CLASS__ . 'LOCALESTATUSDRAFT',
-                'A draft has been created for this Locale, however, published content is still being inherited from
-                another Locale. To publish this content for this Locale, use the "Save & publish" action provided.'
+                'A draft has been created for this locale, however, published content is still being inherited from
+                another locale. To publish this content for this locale, use the "Save & publish" action provided.'
             );
         }
 


### PR DESCRIPTION
Since these messages are designed for content authors, I think they should be lowercased. Page and Locale (if referring to class names) would be for developers.