### PR TITLE
NEW Add task to convert SS3 Translatable data to SS4 Fluent

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -60,6 +60,7 @@ or excluded, either by name, or by type (in order of priority):
 E.g.
 
 ```yaml
+---
 Name: fluentfieldconfig
 ---
 TractorCow\Fluent\Extension\FluentExtension:

--- a/docs/en/domain-configuration.md
+++ b/docs/en/domain-configuration.md
@@ -47,7 +47,7 @@ Either one of:
  * Ensure that all domains configured are the only domains that the site can be accessed under, or
  * Add `SS_FLUENT_FORCE_DOMAIN=true` to your `.env` file, or
  * Set the `TractorCow\Fluent\Extension\FluentDirectorExtension.force_domain` config to true.
-   (this will effect your development environment).
+   (this will affect your development environment).
 
 Outside of these conditions, the domains configuration property will be entirely ignored, meaning you will not normally
 need to alter your SilverStripe configuration between environments.

--- a/docs/en/migrating-from-translatable.md
+++ b/docs/en/migrating-from-translatable.md
@@ -1,0 +1,42 @@
+# Migrating from Translatable
+
+For websites that have been using the [Translatable](https://github.com/silverstripe/silverstripe-translatable)
+module in a SilverStripe 3 project, we have provided a BuildTask that you can run to migrate data into a format
+for Fluent on SilverStripe 4. This can be used, for example, to aid a migration from CWP 1.0 to CWP 2.0, or any
+SilverStripe project previously using Translatable.
+
+## Running the task
+
+To run the automated BuildTask, run the following from your command line:
+
+```
+vendor/bin/sake dev/tasks/ConvertTranslatableTask
+```
+
+This command will do the following:
+
+* Run pre-requisite checks to ensure the system is ready for a data migration to be run - for example, ensuring
+  that you have created some locales in the CMS already
+* Looks up all DataObjects that are Fluent-enabled
+* Find any Translatable database tables for each DataObject
+* Set the Fluent locale for the original record's locale, then;
+* Use the Fluent ORM implementation to write the new data into the database
+* Remove Translatable's data: the Locale column on the base table and the _translationgroups database table
+
+The task is safe to run multiple times, since it will only process a DataObject's data set once due to it cleaning
+up after itself at the end of the task.
+
+## Data structures
+
+Translatable works by adding a "Locale" column to a translated DataObject's database table. This column is then
+used to modify the SilverStripe's ORM SQL queries that are used to read data, essentially allowing the user to
+have multiple websites separated by language.
+
+Fluent (4.x) works in a similar way but doesn't split the base table. Instead it adds localisations to a separate
+table (e.g. SiteTree_Localised), where each locale has a separate row, and if a locale doesn't have a row but has
+a [configured fallback locale](configuration.md) it can return the fallback locale's record instead.
+
+Since Fluent doesn't use the "Locale" column on the base table, we can simply copy pre-localised data from the
+base table and (via the Fluent ORM) insert it directly into the \*_Localised table.
+
+For more information, please see ["How Fluent works"](how-fluent-works.md).

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ you may encounter, as it helps us all out!
  * [Deployment under multiple domains](docs/en/domain-configuration.md)
  * [Templating for Fluent](docs/en/templating.md)
  * [How Fluent works](docs/en/how-fluent-works.md)
+ * [Migrating from Translatable](docs/en/migrating-from-translatable.md)
  * [Changelogs](CHANGELOG.md)
 
 ## License

--- a/src/Task/ConvertTranslatableTask.php
+++ b/src/Task/ConvertTranslatableTask.php
@@ -181,7 +181,7 @@ class ConvertTranslatableTask extends BuildTask
 
                         // Drop the "Locale" column from the base table
                         Debug::message('Dropping "Locale" column from ' . $baseTable, false);
-                        DB::query(sprintf('ALTER TABLE "%s" DROP COLUMN "Locale"', Convert::raw2sql($baseTable)));
+                        DB::query(sprintf('ALTER TABLE "%s" DROP COLUMN "Locale"', $baseTable));
 
                         // Drop the "_translationgroups" translatable table
                         Debug::message('Deleting Translatable table ' . $groupTable, false);

--- a/src/Task/ConvertTranslatableTask.php
+++ b/src/Task/ConvertTranslatableTask.php
@@ -85,9 +85,6 @@ class ConvertTranslatableTask extends BuildTask
 
     public function run($request)
     {
-        // Extend time limit
-        set_time_limit(100000);
-
         $this->checkInstalled();
 
         // we may need some privileges for this to work
@@ -152,8 +149,10 @@ class ConvertTranslatableTask extends BuildTask
 
                             // Check for obsolete classes that don't need to be handled any more
                             if ($instance->ObsoleteClassName) {
-                                Debug::message("Skipping {$instance->ClassName} with ID {$instanceID} because it from an obsolete class",
-                                    false);
+                                Debug::message(
+                                    "Skipping {$instance->ClassName} with ID {$instanceID} because it from an obsolete class",
+                                    false
+                                );
                                 continue;
                             }
 

--- a/src/Task/ConvertTranslatableTask.php
+++ b/src/Task/ConvertTranslatableTask.php
@@ -125,7 +125,7 @@ class ConvertTranslatableTask extends BuildTask
     /**
      * Gets all classes with FluentExtension
      *
-     * @return array Aray of classes to migrate
+     * @return array Array of classes to migrate
      */
     public function fluentClasses()
     {

--- a/src/Task/ConvertTranslatableTask.php
+++ b/src/Task/ConvertTranslatableTask.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace TractorCow\Fluent\Task;
+
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Convert;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\Dev\Debug;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\Security\DefaultAdminService;
+use SilverStripe\Security\Security;
+use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\Extension\FluentFilteredExtension;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
+use TractorCow\Fluent\Task\ConvertTranslatableTask\Exception;
+
+/**
+ * Provides migration from the Translatable module in a SilverStripe 3 website to the Fluent format for SilverStripe 4.
+ * This task assumes that you have upgraded your website to run on SilverStripe 4 already, and you want to migrate the
+ * existing data from your project into a format that is compatible with Fluent.
+ *
+ * Don't forget to:
+ *
+ * 1. Back up your DB
+ * 2. dev/build
+ * 3. Log into the CMS and set up the locales you want to use
+ * 4. Back up your DB again
+ * 5. Log into the CMS and check everything
+ */
+class ConvertTranslatableTask extends BuildTask
+{
+    protected $title = "Convert Translatable > Fluent Task";
+
+    protected $description = "Migrates site DB from SS3 Translatable DB format to SS4 Fluent.";
+
+    private static $segment = 'ConvertTranslatableTask';
+
+    /**
+     * Fields that are localised per class (key = class name)
+     *
+     * @var array[]
+     */
+    protected $localisedFields = [];
+
+    /**
+     * Checks that fluent is configured correctly
+     *
+     * @throws ConvertTranslatableTask\Exception
+     */
+    protected function checkInstalled()
+    {
+        // Assert that fluent is configured
+        $locales = Locale::getLocales();
+        if (empty($locales)) {
+            throw new Exception("Please configure Fluent locales (in the CMS) prior to migrating from translatable");
+        }
+
+        $defaultLocale = Locale::getDefault();
+        if (empty($defaultLocale)) {
+            throw new Exception(
+                "Please configure a Fluent default locale (in the CMS) prior to migrating from translatable"
+            );
+        }
+    }
+
+    /**
+     * Do something inside a DB transaction
+     *
+     * @param callable $callback
+     * @throws \Exception
+     */
+    protected function withTransaction($callback)
+    {
+        try {
+            Debug::message('Beginning transaction', false);
+            DB::get_conn()->transactionStart();
+            $callback($this);
+            Debug::message('Comitting transaction', false);
+            DB::get_conn()->transactionEnd();
+        } catch (\Exception $ex) {
+            Debug::message('Rolling back transaction', false);
+            DB::get_conn()->transactionRollback();
+            throw $ex;
+        }
+    }
+
+    protected $translatedFields = [];
+
+    /**
+     * Get all database fields to translate
+     *
+     * @param string $class Class name
+     * @return array List of translated fields
+     */
+    public function getTranslatedFields($class)
+    {
+        if (isset($this->localisedFields[$class])) {
+            return $this->localisedFields[$class];
+        }
+        $fields = [];
+        $hierarchy = ClassInfo::ancestry($class);
+        foreach ($hierarchy as $class) {
+            // Skip classes without tables
+            if (!DataObject::getSchema()->classHasTable($class)) {
+                continue;
+            }
+
+            // Check fields localised by Fluent for this class
+            $localisedFields = singleton($class)->getLocalisedFields();
+            if (empty($localisedFields)) {
+                continue;
+            }
+
+            // Save fields
+            $fields = array_merge($fields, array_keys($localisedFields));
+        }
+        $this->localisedFields[$class] = $fields;
+        return $fields;
+    }
+
+    /**
+     * Gets all classes with FluentExtension
+     *
+     * @return array Aray of classes to migrate
+     */
+    public function fluentClasses()
+    {
+        $classes = [];
+        $dataClasses = ClassInfo::subclassesFor(DataObject::class);
+        array_shift($dataClasses);
+        foreach ($dataClasses as $class) {
+            $base = DataObject::getSchema()->baseDataClass($class);
+            foreach (DataObject::get_extensions($base) as $extension) {
+                if (is_a($extension, FluentExtension::class, true)) {
+                    $classes[] = $base;
+                    break;
+                }
+            }
+        }
+        return array_unique($classes);
+    }
+
+    public function run($request)
+    {
+        // Extend time limit
+        set_time_limit(100000);
+
+        // we may need some privileges for this to work
+        // without this, running under sake is a problem
+        // maybe sake could take care of it ...
+        Security::setCurrentUser(
+            DefaultAdminService::singleton()->findOrCreateDefaultAdmin()
+        );
+
+        $this->checkInstalled();
+        $this->withTransaction(function (ConvertTranslatableTask $task) {
+            Versioned::set_stage(Versioned::DRAFT);
+            $classes = $task->fluentClasses();
+            $tables = DB::get_schema()->tableList();
+            if (empty($classes)) {
+                Debug::message('No classes have Fluent enabled, so skipping.', false);
+            }
+
+            foreach ($classes as $class) {
+                /** @var DataObject $class */
+
+                // Ensure that a translationgroup table exists for this class
+                $baseTable = DataObject::getSchema()->baseDataTable($class);
+                $groupTable = strtolower($baseTable . "_translationgroups");
+                if (isset($tables[$groupTable])) {
+                    $groupTable = $tables[$groupTable];
+                } else {
+                    Debug::message("Ignoring class without _translationgroups table $class", false);
+                    continue;
+                }
+
+                // Disable filter if it has been applied to the class
+                if (singleton($class)->hasMethod('has_extension')
+                    && $class::has_extension(FluentFilteredExtension::class)
+                ) {
+                    $class::remove_extension(FluentFilteredExtension::class);
+                }
+
+                // Select all instances of this class in the base table, where the Locale field is not null.
+                // Translatable has a Locale column on the base table in SS3, but Fluent doesn't use it. Newly
+                // created records via SS4 Fluent will not set this column, but will set it in {$baseTable}_Localised
+                $instances = DataObject::get($class, sprintf(
+                    '"%s"."Locale" IS NOT NULL',
+                    $baseTable
+                ));
+
+                foreach ($instances as $instance) {
+                    /** @var DataObject $instance */
+
+                    // Get the Locale column directly from the base table, since the SS ORM will not include it
+                    $instanceLocale = SQLSelect::create()
+                        ->setFrom($baseTable)
+                        ->setSelect('Locale')
+                        ->setWhere(['ID' => $instance->ID])
+                        ->execute()
+                        ->first();
+
+                    // Ensure that we got the Locale out of the base table before continuing
+                    if (empty($instanceLocale['Locale'])) {
+                        Debug::message("Skipping {$instance->Title} with ID {$instanceID} - couldn't find Locale");
+                        continue;
+                    }
+                    $instanceLocale = $instanceLocale['Locale'];
+
+                    // Check for obsolete classes that don't need to be handled any more
+                    if ($instance->ObsoleteClassName) {
+                        Debug::message("Skipping {$instance->ClassName} with ID {$instanceID} because it from an obsolete class", false);
+                        continue;
+                    }
+
+                    Debug::message(
+                        "Updating {$instance->ClassName} {$instance->MenuTitle} ({$instance->ID}) with locale {$instanceLocale}",
+                        false
+                    );
+
+                    FluentState::singleton()
+                        ->withState(function (FluentState $state) use ($instance, $instanceLocale) {
+                            // Use Fluent's ORM to write and/or publish the record into the correct locale
+                            // from Translatable
+                            $state->setLocale($instanceLocale);
+
+                            if (!$this->isPublished($instance)) {
+                                $instance->write();
+                                Debug::message("  --  Saved to draft", false);
+                            } elseif ($instance->publishRecursive() === false) {
+                                Debug::message("  --  Publishing FAILED", false);
+                                throw new Exception("Failed to publish");
+                            } else {
+                                Debug::message("  --  Published", false);
+                            }
+                        });
+                }
+
+                // Drop the "Locale" column from the base table
+                Debug::message('Dropping "Locale" column from ' . $baseTable, false);
+                DB::query(sprintf('ALTER TABLE "%s" DROP COLUMN "Locale"', Convert::raw2sql($baseTable)));
+
+                // Drop the "_translationgroups" translatable table
+                Debug::message('Deleting Translatable table ' . $groupTable, false);
+                DB::query(sprintf('DROP TABLE IF EXISTS "%s"', $groupTable));
+            }
+        });
+    }
+
+    /**
+     * Determine whether the record has been published previously/is currently published
+     *
+     * @param DataObject $instance
+     * @return bool
+     */
+    protected function isPublished(DataObject $instance)
+    {
+        $isPublished = false;
+        if ($instance->hasMethod('isPublished')) {
+            $isPublished = $instance->isPublished();
+        }
+        return $isPublished;
+    }
+}

--- a/src/Task/ConvertTranslatableTask/Exception.php
+++ b/src/Task/ConvertTranslatableTask/Exception.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TractorCow\Fluent\Task\ConvertTranslatableTask;
+
+class Exception extends \Exception
+{
+
+}


### PR DESCRIPTION
To run this task, ensure you have updated your system to SS4, run a dev/build
and added the locales you need to use in the CMS Locale interface. Next run
the build task, which will write and/or publish your content via the Fluent
ORM, then clean up the old Translatable tables and extra columns.

This task is based on the existing task from SS3.

Part of #328 