### PR TITLE
ENHANCEMENT: Set SS locale to match requested one

### DIFF
--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -7,6 +7,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\i18n\i18n;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Model\Domain;
 use TractorCow\Fluent\Model\Locale;
@@ -56,11 +57,15 @@ class DetectLocaleMiddleware implements HTTPMiddleware
     public function process(HTTPRequest $request, callable $delegate)
     {
         $state = FluentState::singleton();
+        $locale = $state->getLocale();
 
-        if (!$state->getLocale()) {
+        if (!$locale) {
             $locale = $this->getLocale($request);
-
             $state->setLocale($locale);
+        }
+
+        if ($locale && $state->getIsFrontend()) {
+            i18n::set_locale($state->getLocale());
         }
 
         // Always persist the current locale


### PR DESCRIPTION
Fluent is great for changing CMS edited content to a different locale per request.
However this does not alter all the template and PHP managed translation such as
FormField labels, or template controlled headings. This leads to odd end user
experiences where someone may be viewing the German content, and have it labelled
by English. This fix sets the i18n class locale to the same as the requested one
used by Fluent to give a consistent and far less confusing experience. This is
limited to the 'front end' (non CMS) site as e.g. it is feasible that a content
editor in Germany who is fluent in English would want the interface to remain in
German.
Resolves #327 