### PR TITLE
Only apply query change when `Locale::getCached()->count()` is true

### DIFF
--- a/src/Search/FluentSearchVariant.php
+++ b/src/Search/FluentSearchVariant.php
@@ -46,7 +46,7 @@ class FluentSearchVariant extends SearchVariant
 
     public function alterQuery($query, $index)
     {
-        if (FluentState::singleton()->getIsFrontend()) {
+        if (FluentState::singleton()->getIsFrontend() && Locale::getCached()->count()) {
             $query->filter('_locale', [
                 $this->currentState(),
                 SearchQuery::$missing


### PR DESCRIPTION
Fixes an issue where the Variant applies `_locale` to queries but not the index.