### PR TITLE
Allow cookie domain and path to be configurable

### DIFF
--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -46,7 +46,7 @@ class DetectLocaleMiddleware implements HTTPMiddleware
      * Use this path when setting the locale cookie
      *
      * @config
-     * @var int
+     * @var string
      */
     private static $persist_cookie_path = null;
 
@@ -54,7 +54,7 @@ class DetectLocaleMiddleware implements HTTPMiddleware
      * Use this domain when setting the locale cookie
      *
      * @config
-     * @var int
+     * @var string
      */
     private static $persist_cookie_domain = null;
 

--- a/src/Middleware/DetectLocaleMiddleware.php
+++ b/src/Middleware/DetectLocaleMiddleware.php
@@ -43,6 +43,22 @@ class DetectLocaleMiddleware implements HTTPMiddleware
     private static $persist_cookie_expiry = 90;
 
     /**
+     * Use this path when setting the locale cookie
+     *
+     * @config
+     * @var int
+     */
+    private static $persist_cookie_path = null;
+
+    /**
+     * Use this domain when setting the locale cookie
+     *
+     * @config
+     * @var int
+     */
+    private static $persist_cookie_domain = null;
+
+    /**
      * Whether cookies have already been set during {@link setPersistLocale()}
      *
      * @var bool
@@ -163,7 +179,15 @@ class DetectLocaleMiddleware implements HTTPMiddleware
 
         // Don't set cookie if headers already sent
         if (!headers_sent()) {
-            Cookie::set($key, $locale, static::config()->get('persist_cookie_expiry'), null, null, false, false);
+            Cookie::set(
+                $key,
+                $locale,
+                static::config()->get('persist_cookie_expiry'),
+                static::config()->get('persist_cookie_path'),
+                static::config()->get('persist_cookie_domain'),
+                false,
+                false
+            );
         }
 
         return $this;


### PR DESCRIPTION
We have two components to our websites: the marketing website which runs on [www.](https://www.royalalberthall.com/tickets/events/2018/nine-inch-nails/) and the purchase path which runs on [tickets.](https://tickets.royalalberthall.com/booking/production/bestavailable/60640)

The marketing site needs to set the cookie so that the tickets. domain has access to it, which is a problem because the module will only set the persist cookie on the current domain.

Two options to get around this is set cookie to be set on domain without the subdomain i.e. `.example.com` but that's not really required if we just allow the cookie domain to be set, which is option two.

The PR exposes two variables which will let the user specify the path using `persist_cookie_path` and domain using `persist_cookie_domain` using the config, falling back to `null` if not set (which is basically what the module currently does).

```yaml
TractorCow\Fluent\Middleware\DetectLocaleMiddleware:
  persist_cookie_domain: .wmc.site
```

![image](https://user-images.githubusercontent.com/377860/37567121-113a3e7a-2aba-11e8-8791-ea8f8c3771a7.png)
