### PR TITLE
Update date format in sitemap template

### DIFF
--- a/templates/Wilr/GoogleSitemaps/Control/GoogleSitemapController_sitemap.ss
+++ b/templates/Wilr/GoogleSitemaps/Control/GoogleSitemapController_sitemap.ss
@@ -4,7 +4,7 @@
 	<% loop $Items %>
         <url>
             <loc>$AbsoluteLink</loc>
-            <% if $LastEdited %><lastmod>$LastEdited.Format("y-MM-dd'T'HH:mm:ss")</lastmod><% end_if %>
+            <% if $LastEdited %><lastmod>$LastEdited.Rfc3339()</lastmod><% end_if %>
             <% if $ChangeFrequency %><changefreq>$ChangeFrequency</changefreq><% end_if %>
             <% if $GooglePriority %><priority>$GooglePriority</priority><% end_if %>
             <% if $Locales %><% loop $Locales %><% if $LinkingMode != 'invalid' %>


### PR DESCRIPTION
Google reports invalid date format on generated sitemaps.
Changing to the rfc3339 format, including the timezone offset cure the problem.

(This has already been included in the standard sitemaps addon)