### PR TITLE
FIX Cast default locale title as a DBField to prevent search field scaffolding error

### DIFF
--- a/src/Model/Domain.php
+++ b/src/Model/Domain.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\HasManyList;
 use TractorCow\Fluent\State\FluentState;
 
@@ -139,13 +140,13 @@ class Domain extends DataObject
     }
 
     /**
-     * @return string
+     * @return DBField|null
      */
     public function DefaultLocaleTitle()
     {
         $locale = $this->DefaultLocale();
         if ($locale) {
-            return $locale->getTitle();
+            return DBField::create_field('Text', $locale->getTitle());
         }
         return null;
     }


### PR DESCRIPTION
On SS 4.1.0 returning a string in this GridField summary field throws an exception. Instead, we should cast it as a DBField.

Resolves #380 