### PR TITLE
Fix for duplicate indexes with inheritence

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -295,6 +295,9 @@ class FluentExtension extends DataExtension
             $localisedFields
         );
         $indexes = $this->owner->config()->get('indexes_for_localised_table');
+        foreach ($indexes as &$value) {
+            $value['columns'] = array_unique($value['columns']);
+        }
         $this->augmentDatabaseRequireTable($localisedTable, $fields, $indexes);
     }
 


### PR DESCRIPTION
If you have 2 DataObjects where one is inheriting from the other and they second has additional fields that need to be fluented then the "Fluent_Record" index tries to use 2 RecordID fields in the index

Alternative is to fluent all fields on the parent DataObject even though they're only part of child objects