### PR TITLE
Update composer requirement constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "silverstripe/vendor-plugin": "^1",
         "silverstripe/framework": "^4",
         "silverstripe/cms": "^4",
-        "symbiote/silverstripe-gridfieldextensions": "^3"
+        "symbiote/silverstripe-gridfieldextensions": "^3.0.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         "issues": "http://github.com/tractorcow/silverstripe-fluent/issues"
     },
     "require": {
-        "silverstripe/vendor-plugin": "^1.0",
-        "silverstripe/framework": "^4@dev",
-        "silverstripe/cms": "^4@dev",
-        "symbiote/silverstripe-gridfieldextensions": "^3.0.3@dev"
+        "silverstripe/vendor-plugin": "^1",
+        "silverstripe/framework": "^4",
+        "silverstripe/cms": "^4",
+        "symbiote/silverstripe-gridfieldextensions": "^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
Although inconsequential, the current constraints are all marked as dev - an overhang from when SilverStripe 4 was in pre-release stages. This is no longer necessary, so we can remove them in order to keep the constraints more in line with other modules (such as the requirements here) and easier to read.