### PR TITLE
Change getLocalisedTables method to public.

### DIFF
--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -227,7 +227,7 @@ class FluentExtension extends DataExtension
      *
      * @return array
      */
-    protected function getLocalisedTables()
+    public function getLocalisedTables()
     {
         $includedTables = [];
         $baseClass = $this->owner->baseClass();


### PR DESCRIPTION
I have found that the `getLocalisedTables()` method is incredibly useful for some of the project specific *oddities* that we've been adding. Can we please make it public so that I don't have to duplicate the logic elsewhere?