### PR TITLE
ENHANCEMENT Shift extension default to yml file to promote better extensibility

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -1,0 +1,6 @@
+---
+Name: fluentmodel
+---
+SilverStripe\ORM\DataObject:
+  frontend_publish_required: true
+

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -907,14 +907,6 @@ class FluentExtension extends DataExtension
             return false;
         }
 
-        // Check legacy (deprecated) config
-        $frontendPublishRequired = $this->owner->config()->get('frontend_publish_required');
-        if (isset($frontendPublishRequired)) {
-            Deprecation::notification_version('5.0.0', 'Use ignore_frontend_publish=true instead');
-            return (bool)$frontendPublishRequired;
-        }
-
-        // Require saved unless ignoring frontend published
-        return !$this->owner->config()->get('ignore_frontend_publish');
+        return $this->owner->config()->get('frontend_publish_required');
     }
 }


### PR DESCRIPTION
Fixes #406

Replacement solution for https://github.com/tractorcow/silverstripe-fluent/pull/407

Instead of adding the config via extension (which cannot be easily overridden on a model by model basis via yml) add the default config via yml.

@dhensby I think this might be a better convention going forward; Promote use of yml for configs, rather than adding private statics to extension classes. What is your feeling on this?