### PR TITLE
v4: Proposal to add config setting for CMS publish required.

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -2,5 +2,6 @@
 Name: fluentmodel
 ---
 SilverStripe\ORM\DataObject:
+  cms_publish_required: false
   frontend_publish_required: true
 

--- a/src/Extension/FluentExtension.php
+++ b/src/Extension/FluentExtension.php
@@ -919,11 +919,10 @@ class FluentExtension extends DataExtension
      */
     protected function requireSavedInLocale()
     {
-        // Filter is disabled in CMS
-        if (!FluentState::singleton()->getIsFrontend()) {
-            return false;
+        if (FluentState::singleton()->getIsFrontend()) {
+            return $this->owner->config()->get('frontend_publish_required');
         }
 
-        return $this->owner->config()->get('frontend_publish_required');
+        return $this->owner->config()->get('cms_publish_required');
     }
 }

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -10,6 +10,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ArrayData;
 use TractorCow\Fluent\Extension\FluentDirectorExtension;
 use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
@@ -255,8 +256,32 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         $this->assertSame($expected, $segmentField->getURLPrefix());
     }
 
-    public function testHomeNotVisibleOnFrontend()
+    public function testHomeVisibleOnFrontendBothConfigFalse()
     {
+        Config::modify()->set(DataObject::class, 'cms_publish_required', false);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
+        FluentState::singleton()->setIsFrontend(true);
+
+        $page = Page::get()->filter('URLSegment', 'home')->first();
+
+        $this->assertNotNull($page);
+    }
+
+    public function testHomeVisibleOnFrontendOneConfigFalse()
+    {
+        Config::modify()->set(DataObject::class, 'cms_publish_required', true);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
+        FluentState::singleton()->setIsFrontend(true);
+
+        $page = Page::get()->filter('URLSegment', 'home')->first();
+
+        $this->assertNotNull($page);
+    }
+
+    public function testHomeNotVisibleOnFrontendBothConfigTrue()
+    {
+        Config::modify()->set(DataObject::class, 'cms_publish_required', true);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
         FluentState::singleton()->setIsFrontend(true);
 
         $page = Page::get()->filter('URLSegment', 'home')->first();
@@ -264,13 +289,59 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         $this->assertNull($page);
     }
 
-    public function testHomeVisibleInCMS()
+    public function testHomeNotVisibleOnFrontendOneConfigTrue()
     {
+        Config::modify()->set(DataObject::class, 'cms_publish_required', false);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
+        FluentState::singleton()->setIsFrontend(true);
+
+        $page = Page::get()->filter('URLSegment', 'home')->first();
+
+        $this->assertNull($page);
+    }
+
+    public function testHomeVisibleInCMSBothConfigFalse()
+    {
+        Config::modify()->set(DataObject::class, 'cms_publish_required', false);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
         FluentState::singleton()->setIsFrontend(false);
 
         $page = Page::get()->filter('URLSegment', 'home')->first();
 
         $this->assertNotNull($page);
+    }
+
+    public function testHomeVisibleInCMSOneConfigFalse()
+    {
+        Config::modify()->set(DataObject::class, 'cms_publish_required', false);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
+        FluentState::singleton()->setIsFrontend(false);
+
+        $page = Page::get()->filter('URLSegment', 'home')->first();
+
+        $this->assertNotNull($page);
+    }
+
+    public function testHomeNotVisibleInCMSBothConfigTrue()
+    {
+        Config::modify()->set(DataObject::class, 'cms_publish_required', true);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', true);
+        FluentState::singleton()->setIsFrontend(false);
+
+        $page = Page::get()->filter('URLSegment', 'home')->first();
+
+        $this->assertNull($page);
+    }
+
+    public function testHomeNotVisibleInCMSOneConfigTrue()
+    {
+        Config::modify()->set(DataObject::class, 'cms_publish_required', true);
+        Config::modify()->set(DataObject::class, 'frontend_publish_required', false);
+        FluentState::singleton()->setIsFrontend(false);
+
+        $page = Page::get()->filter('URLSegment', 'home')->first();
+
+        $this->assertNull($page);
     }
 
     /**

--- a/tests/php/Extension/FluentSiteTreeExtensionTest.php
+++ b/tests/php/Extension/FluentSiteTreeExtensionTest.php
@@ -255,6 +255,24 @@ class FluentSiteTreeExtensionTest extends SapphireTest
         $this->assertSame($expected, $segmentField->getURLPrefix());
     }
 
+    public function testHomeNotVisibleOnFrontend()
+    {
+        FluentState::singleton()->setIsFrontend(true);
+
+        $page = Page::get()->filter('URLSegment', 'home')->first();
+
+        $this->assertNull($page);
+    }
+
+    public function testHomeVisibleInCMS()
+    {
+        FluentState::singleton()->setIsFrontend(false);
+
+        $page = Page::get()->filter('URLSegment', 'home')->first();
+
+        $this->assertNotNull($page);
+    }
+
     /**
      * @return array[]
      */


### PR DESCRIPTION
We currently have this logic sitting in project code through an extension, and I'm more than happy for it to stay there, but...

## The situation
Current project relies heavily on `DataObject`s that are managed through a 3rd party system - there is no ability to modify these `DataObject`s in SilverStripe, but they can be viewed and they can be added as relationships on other `DataObject`s.

As such, we have a requirement to hide un-localised `DataObject`s not only on the frontend, but in the CMS as well (so that authors don't add unavailable `DataObject`s as relationships).

## Proposal
Add a config value for `cms_publish_required` so that devs can separately control frontend and CMS visibility options.