### PR TITLE
FIX Ensure alterQuery is compatible with silverstripe/fulltextsearch <3.3

### DIFF
--- a/src/Search/FluentSearchVariant.php
+++ b/src/Search/FluentSearchVariant.php
@@ -2,13 +2,13 @@
 
 namespace TractorCow\Fluent\Search;
 
-use TractorCow\Fluent\Extension\FluentExtension;
-use TractorCow\Fluent\State\FluentState;
-use TractorCow\Fluent\Model\Locale;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\FullTextSearch\Search\Variants\SearchVariant;
-use SilverStripe\FullTextSearch\Search\SearchIntrospection;
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
+use SilverStripe\FullTextSearch\Search\SearchIntrospection;
+use SilverStripe\FullTextSearch\Search\Variants\SearchVariant;
+use SilverStripe\ORM\DataObject;
+use TractorCow\Fluent\Extension\FluentExtension;
+use TractorCow\Fluent\Model\Locale;
+use TractorCow\Fluent\State\FluentState;
 
 if (!class_exists(SearchVariant::class)) {
     return;
@@ -47,7 +47,9 @@ class FluentSearchVariant extends SearchVariant
     public function alterQuery($query, $index)
     {
         if (FluentState::singleton()->getIsFrontend() && Locale::getCached()->count()) {
-            $query->addFilter('_locale', [
+            // Backwards compatibility for silverstripe/fulltextsearch 3.2/3.3
+            $method = method_exists($query, 'addFilter') ? 'addFilter' : 'filter';
+            $query->$method('_locale', [
                 $this->currentState(),
                 SearchQuery::$missing
             ]);


### PR DESCRIPTION
Follow up on https://github.com/tractorcow/silverstripe-fluent/pull/450

This supports older versions, since we don't mandate fulltextsearch 3.3 as a requirement.