### PR TITLE
3.8:  Make Fluent compatible to SilverStripe 3.7.x / PHP 7.2 

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,6 @@
+<?php
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) {
+    class_alias('Object', 'SS_Object');
+}

--- a/code/Fluent.php
+++ b/code/Fluent.php
@@ -6,7 +6,7 @@
  * @package fluent
  * @author Damian Mooyman <damian.mooyman@gmail.com>
  */
-class Fluent extends Object implements TemplateGlobalProvider
+class Fluent extends SS_Object implements TemplateGlobalProvider
 {
     /**
      * If set, "is_frontend" can be forced to return a value


### PR DESCRIPTION
 Ensure compatibility with PHP 7.2 ("object" is a reserved word), with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)