### PR TITLE
v4: Added config setting to bypass filtered locale logic in stage. Fixes #461

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -3,4 +3,4 @@ Name: fluentmodel
 ---
 SilverStripe\ORM\DataObject:
   frontend_publish_required: true
-
+  apply_filtered_locales_to_stage: true

--- a/src/Extension/FluentFilteredExtension.php
+++ b/src/Extension/FluentFilteredExtension.php
@@ -161,15 +161,15 @@ class FluentFilteredExtension extends DataExtension
      *
      * @return bool
      */
-    private function getModeIsStage()
+    protected function getModeIsStage()
     {
-        $str = Versioned::get_reading_mode();
-        $test = Versioned::DRAFT;
+        $readingMode = Versioned::get_reading_mode();
+        $draft = Versioned::DRAFT;
 
-        if (strlen($str) === 0) {
-            $str = Versioned::DEFAULT_MODE;
+        if (strlen($readingMode) === 0) {
+            $readingMode = Versioned::DEFAULT_MODE;
         }
 
-        return substr_compare($str, $test, strlen($str) - strlen($test), strlen($test)) === 0;
+        return substr_compare($readingMode, $draft, strlen($readingMode) - strlen($draft), strlen($draft)) === 0;
     }
 }

--- a/tests/php/Extension/FluentFilteredExtensionTest.php
+++ b/tests/php/Extension/FluentFilteredExtensionTest.php
@@ -53,7 +53,7 @@ class FluentFilteredExtensionTest extends SapphireTest
                 ->setLocale('en_NZ')
                 ->setIsFrontend(true);
 
-            $this->assertEquals(1, SiteTree::get()->count());
+            $this->assertCount(1, SiteTree::get());
         });
 
         if ($currentStage) {
@@ -80,7 +80,7 @@ class FluentFilteredExtensionTest extends SapphireTest
                 ->setLocale('en_NZ')
                 ->setIsFrontend(true);
 
-            $this->assertEquals(0, SiteTree::get()->count());
+            $this->assertCount(0, SiteTree::get());
         });
 
         if ($currentStage) {
@@ -108,7 +108,7 @@ class FluentFilteredExtensionTest extends SapphireTest
                 ->setLocale('en_NZ')
                 ->setIsFrontend(true);
 
-            $this->assertEquals(2, SiteTree::get()->count());
+            $this->assertCount(2, SiteTree::get());
         });
 
         if ($currentStage) {
@@ -123,7 +123,7 @@ class FluentFilteredExtensionTest extends SapphireTest
                 ->setLocale('en_NZ')
                 ->setIsFrontend(false);
 
-            $this->assertEquals(2, SiteTree::get()->count());
+            $this->assertCount(2, SiteTree::get());
         });
     }
 


### PR DESCRIPTION
I wasn't too sure if we wanted the default set to `true` or `false`. Having it as `true` by default leaves functionality the same as it is atm. Maybe next major release we could change that.