### PR TITLE
ENHANCEMENT: Update unit tests to use withState where appropriate. Resolves #462

### DIFF
--- a/tests/php/Extension/FluentBadgeExtensionTest.php
+++ b/tests/php/Extension/FluentBadgeExtensionTest.php
@@ -44,12 +44,14 @@ class FluentBadgeExtensionTest extends SapphireTest
         // Clear cache
         Locale::clearCached();
 
-        FluentState::singleton()->setLocale('en_NZ');
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState->setLocale('en_NZ');
 
-        $this->mockPage = $this->objFromFixture(SiteTree::class, 'test_page');
-        $this->mockController = new FluentStubController($this->mockPage->ID);
-        $this->extension = new FluentBadgeExtension();
-        $this->extension->setOwner($this->mockController);
+            $this->mockPage = $this->objFromFixture(SiteTree::class, 'test_page');
+            $this->mockController = new FluentStubController($this->mockPage->ID);
+            $this->extension = new FluentBadgeExtension();
+            $this->extension->setOwner($this->mockController);
+        });
     }
 
     public function testDefaultLocaleBadgeAdded()
@@ -58,24 +60,26 @@ class FluentBadgeExtensionTest extends SapphireTest
         FluentState::singleton()->withState(function (FluentState $newState) {
             $newState->setLocale('en_NZ');
             $this->mockPage->publishRecursive();
-        });
 
-        $result = $this->extension->getBadge($this->mockPage);
-        $this->assertInstanceOf(DBHTMLText::class, $result);
-        $this->assertContains('fluent-badge--default', $result->getValue());
-        $this->assertContains('Default locale', $result->getValue());
-        $this->assertContains('NZ', $result->getValue(), 'Badge shows owner locale');
+            $result = $this->extension->getBadge($this->mockPage);
+            $this->assertInstanceOf(DBHTMLText::class, $result);
+            $this->assertContains('fluent-badge--default', $result->getValue());
+            $this->assertContains('Default locale', $result->getValue());
+            $this->assertContains('NZ', $result->getValue(), 'Badge shows owner locale');
+        });
     }
 
     public function testInvisibleLocaleBadgeWasAdded()
     {
-        // Don't write the page in the non-default locale, then it shouldn't exist
-        FluentState::singleton()->setLocale('de_DE');
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            // Don't write the page in the non-default locale, then it shouldn't exist
+            $newState->setLocale('de_DE');
 
-        $result = $this->extension->getBadge($this->mockPage);
-        $this->assertInstanceOf(DBHTMLText::class, $result);
-        $this->assertContains('fluent-badge--invisible', $result->getValue());
-        $this->assertContains('is not visible in this locale', $result->getValue());
-        $this->assertContains('NZ', $result->getValue(), 'Badge shows owner locale');
+            $result = $this->extension->getBadge($this->mockPage);
+            $this->assertInstanceOf(DBHTMLText::class, $result);
+            $this->assertContains('fluent-badge--invisible', $result->getValue());
+            $this->assertContains('is not visible in this locale', $result->getValue());
+            $this->assertContains('NZ', $result->getValue(), 'Badge shows owner locale');
+        });
     }
 }

--- a/tests/php/Extension/FluentFilteredExtensionTest.php
+++ b/tests/php/Extension/FluentFilteredExtensionTest.php
@@ -29,54 +29,66 @@ class FluentFilteredExtensionTest extends SapphireTest
         // Clear cache
         Locale::clearCached();
         Domain::clearCached();
-        FluentState::singleton()
-            ->setLocale('en_NZ')
-            ->setIsDomainMode(false);
     }
 
     public function testAugmentSQLFrontend()
     {
-        FluentState::singleton()
-            ->setLocale('en_NZ')
-            ->setIsFrontend(true);
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('en_NZ')
+                ->setIsFrontend(true)
+                ->setIsDomainMode(false);
 
-        $this->assertEquals(1, SiteTree::get()->count());
+            $this->assertEquals(1, SiteTree::get()->count());
+        });
     }
 
     public function testAugmentSQLCMS()
     {
-        FluentState::singleton()
-            ->setLocale('en_NZ')
-            ->setIsFrontend(false);
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('en_NZ')
+                ->setIsFrontend(false)
+                ->setIsDomainMode(false);
 
-        $this->assertEquals(2, SiteTree::get()->count());
+            $this->assertEquals(2, SiteTree::get()->count());
+        });
     }
 
     public function testUpdateCMSFields()
     {
-        /** @var Page|FluentSiteTreeExtension $page */
-        $page = SiteTree::get()->filter('URLSegment', 'home')->first();
-        $fields = $page->getCMSFields();
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('en_NZ')
+                ->setIsDomainMode(false);
 
-        $this->assertNotNull($fields->dataFieldByName('FilteredLocales'));
+            /** @var Page|FluentSiteTreeExtension $page */
+            $page = SiteTree::get()->filter('URLSegment', 'home')->first();
+            $fields = $page->getCMSFields();
+
+            $this->assertNotNull($fields->dataFieldByName('FilteredLocales'));
+        });
     }
 
     public function testUpdateStatusFlags()
     {
-        FluentState::singleton()
-            ->setLocale('en_US')
-            ->setIsFrontend(false);
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('en_US')
+                ->setIsFrontend(false)
+                ->setIsDomainMode(false);
 
-        /** @var Page|FluentSiteTreeExtension $page */
-        $page = $this->objFromFixture('Page', 'about');
-        $flags = $page->getStatusFlags();
+            /** @var Page|FluentSiteTreeExtension $page */
+            $page = $this->objFromFixture('Page', 'about');
+            $flags = $page->getStatusFlags();
 
-        $this->assertTrue(array_key_exists('fluentfiltered', $flags));
+            $this->assertTrue(array_key_exists('fluentfiltered', $flags));
 
-        if (!array_key_exists('fluentfiltered', $flags)) {
-            return;
-        }
+            if (!array_key_exists('fluentfiltered', $flags)) {
+                return;
+            }
 
-        $this->assertEquals('Filtered', $flags['fluentfiltered']['text']);
+            $this->assertEquals('Filtered', $flags['fluentfiltered']['text']);
+        });
     }
 }

--- a/tests/php/Extension/FluentVersionedExtensionTest.php
+++ b/tests/php/Extension/FluentVersionedExtensionTest.php
@@ -27,42 +27,63 @@ class FluentVersionedExtensionTest extends SapphireTest
         // Clear cache
         Locale::clearCached();
         Domain::clearCached();
-        FluentState::singleton()
-            ->setLocale('en_NZ')
-            ->setIsDomainMode(false);
     }
 
     public function testIsDraftedInLocale()
     {
-        /** @var Page $page */
-        $page = $this->objFromFixture(Page::class, 'home');
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('en_NZ')
+                ->setIsDomainMode(false);
 
-        $this->assertTrue($page->isDraftedInLocale());
+            /** @var Page $page */
+            $page = $this->objFromFixture(Page::class, 'home');
+
+            $this->assertTrue($page->isDraftedInLocale());
+        });
     }
 
     public function testIsPublishedInLocale()
     {
-        /** @var Page $page */
-        $page = $this->objFromFixture(Page::class, 'home');
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('en_NZ')
+                ->setIsDomainMode(false);
 
-        $this->assertTrue($page->isPublishedInLocale());
+            /** @var Page $page */
+            $page = $this->objFromFixture(Page::class, 'home');
+
+            $this->assertTrue($page->isPublishedInLocale());
+        });
     }
 
     public function testExistsInLocale()
     {
-        /** @var Page $page */
-        $page = $this->objFromFixture(Page::class, 'home');
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('en_NZ')
+                ->setIsDomainMode(false);
 
-        $this->assertTrue($page->existsInLocale());
+            /** @var Page $page */
+            $page = $this->objFromFixture(Page::class, 'home');
+
+            $this->assertTrue($page->existsInLocale());
+        });
     }
 
     /** @group wip */
     public function testSourceLocaleIsCurrentWhenPageExistsInIt()
     {
-        // Read from the locale that the page exists in already
-        /** @var Page $page */
-        $page = $this->objFromFixture(Page::class, 'home');
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState
+                ->setLocale('en_NZ')
+                ->setIsDomainMode(false);
 
-        $this->assertEquals('en_NZ', $page->getSourceLocale()->Locale);
+            // Read from the locale that the page exists in already
+            /** @var Page $page */
+            $page = $this->objFromFixture(Page::class, 'home');
+
+            $this->assertEquals('en_NZ', $page->getSourceLocale()->Locale);
+        });
     }
 }

--- a/tests/php/Middleware/DetectLocaleMiddlewareTest.php
+++ b/tests/php/Middleware/DetectLocaleMiddlewareTest.php
@@ -39,12 +39,13 @@ class DetectLocaleMiddlewareTest extends SapphireTest
 
     public function testGetPersistKey()
     {
-        $state = FluentState::singleton();
-        $state->setIsFrontend(true);
-        $this->assertSame('FluentLocale', $this->middleware->getPersistKey());
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $newState->setIsFrontend(true);
+            $this->assertSame('FluentLocale', $this->middleware->getPersistKey());
 
-        $state->setIsFrontend(false);
-        $this->assertSame('FluentLocale_CMS', $this->middleware->getPersistKey());
+            $newState->setIsFrontend(false);
+            $this->assertSame('FluentLocale_CMS', $this->middleware->getPersistKey());
+        });
     }
 
     /**
@@ -94,19 +95,21 @@ class DetectLocaleMiddlewareTest extends SapphireTest
 
     public function testLocaleIsAlwaysPersistedEvenIfNotSetByTheMiddleware()
     {
-        $request = new HTTPRequest('GET', '/');
-        FluentState::singleton()->setLocale('dummy');
+        FluentState::singleton()->withState(function (FluentState $newState) {
+            $request = new HTTPRequest('GET', '/');
+            $newState->setLocale('dummy');
 
-        /** @var DetectLocaleMiddleware|PHPUnit_Framework_MockObject_MockObject $middleware */
-        $middleware = $this->getMockBuilder(DetectLocaleMiddleware::class)
-            ->setMethods(['getLocale', 'setPersistLocale'])
-            ->getMock();
+            /** @var DetectLocaleMiddleware|PHPUnit_Framework_MockObject_MockObject $middleware */
+            $middleware = $this->getMockBuilder(DetectLocaleMiddleware::class)
+                ->setMethods(['getLocale', 'setPersistLocale'])
+                ->getMock();
 
-        $middleware->expects($this->never())->method('getLocale');
-        $middleware->expects($this->once())->method('setPersistLocale')->with($request, 'dummy');
+            $middleware->expects($this->never())->method('getLocale');
+            $middleware->expects($this->once())->method('setPersistLocale')->with($request, 'dummy');
 
-        $middleware->process($request, function () {
-            // no-op
+            $middleware->process($request, function () {
+                // no-op
+            });
         });
     }
 }


### PR DESCRIPTION
Failing tests are the sorting ones we're already aware of.

Desired outcome is that nothing has changed. Using `withState` just keeps everything nicely in a bubble.

Resolves #462